### PR TITLE
[feat] 인원선택 바텀시트 기능 구현

### DIFF
--- a/CGV/Presentation/Seats/View/GuestCountSheetView.swift
+++ b/CGV/Presentation/Seats/View/GuestCountSheetView.swift
@@ -40,17 +40,17 @@ final class GuestCountSheetView: BaseView {
     
     private let discountLabel = UILabel()
     
-    private let generalButton = GuestCountButton(count: 0)
+    let generalButton = GuestCountButton(count: 0)
     
-    private let youthButton = GuestCountButton(count: 0)
+    let youthButton = GuestCountButton(count: 0)
     
-    private let seniorButton = GuestCountButton(count: 0)
+    let seniorButton = GuestCountButton(count: 0)
     
-    private let discountButton = GuestCountButton(count: 0)
+    let discountButton = GuestCountButton(count: 0)
     
-    private let backButton = UIButton()
+    let backButton = UIButton()
     
-    private let selectButton = UIButton()
+    let selectButton = UIButton()
     
     override func setStyle() {
         titleLabel.do {
@@ -139,6 +139,7 @@ final class GuestCountSheetView: BaseView {
             $0.setTitle("좌석선택", style: Kopub.head7, color: .cgvWhite)
             $0.backgroundColor = .cgvG500
             $0.layer.cornerRadius = 12
+            $0.isEnabled = false
         }
     }
     

--- a/CGV/Presentation/Seats/View/GuestCountSheetView.swift
+++ b/CGV/Presentation/Seats/View/GuestCountSheetView.swift
@@ -12,6 +12,8 @@ import Then
 
 final class GuestCountSheetView: BaseView {
     
+    // MARK: - UIComponent
+    
     private let titleLabel = UILabel()
     
     private let dateLabel = UILabel()
@@ -51,6 +53,8 @@ final class GuestCountSheetView: BaseView {
     let backButton = UIButton()
     
     let selectButton = UIButton()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         titleLabel.do {

--- a/CGV/Presentation/Seats/ViewController/GuestCountSheetViewController.swift
+++ b/CGV/Presentation/Seats/ViewController/GuestCountSheetViewController.swift
@@ -9,15 +9,104 @@ import UIKit
 
 final class GuestCountSheetViewController: BaseViewController {
     
+    // MARK: - Property
+    
     private let rootView = GuestCountSheetView()
+    
+    private var totalGuestCount: Int = 0
+    
+    private var isValid: Bool = false
+    
+    // MARK: - LifeCycle
     
     override func loadView() {
         view = rootView
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    // MARK: - Action
+    
+    override func setupAction() {
+        rootView.generalButton.minusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
         
+        rootView.generalButton.plusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.youthButton.minusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.youthButton.plusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.seniorButton.minusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.seniorButton.plusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.discountButton.minusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.discountButton.plusButton.addTarget(
+            self,
+            action: #selector(guestCountButtonDidTap),
+            for: .touchUpInside
+        )
+        
+        rootView.selectButton.addTarget(
+            self,
+            action: #selector(selectButtonDidTap),
+            for: .touchUpInside
+        )
     }
     
+    // MARK: - Function
+
+    private func calcTotalGuestCount() {
+        let generalCount = rootView.generalButton.currentCount
+        let youthCount = rootView.youthButton.currentCount
+        let seniorCount = rootView.seniorButton.currentCount
+        let discountCount = rootView.discountButton.currentCount
+        
+        totalGuestCount = generalCount + youthCount + seniorCount + discountCount
+    }
+    
+    private func checkValid() {
+        isValid = totalGuestCount >= 1 && totalGuestCount <= 8
+        
+        rootView.selectButton.backgroundColor = isValid ? .cgvR400 : .cgvG500
+        rootView.selectButton.isEnabled = isValid ? true : false
+    }
+    
+    @objc
+    private func guestCountButtonDidTap() {
+        calcTotalGuestCount()
+        checkValid()
+    }
+    
+    @objc
+    private func selectButtonDidTap() {
+        dismiss(animated: true, completion: nil)
+    }
 }

--- a/CGV/Presentation/Seats/ViewController/SeatsViewController.swift
+++ b/CGV/Presentation/Seats/ViewController/SeatsViewController.swift
@@ -9,10 +9,7 @@ import UIKit
 
 final class SeatsViewController: BaseViewController {
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-    }
+    // MARK: - LifeCycle
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -20,6 +17,8 @@ final class SeatsViewController: BaseViewController {
         presentGuestCountSheet()
     }
 }
+
+// MARK: - UIAdaptivePresentationControllerDelegate
 
 extension SeatsViewController: UIAdaptivePresentationControllerDelegate {
     func presentGuestCountSheet() {

--- a/CGV/Presentation/Seats/ViewController/SeatsViewController.swift
+++ b/CGV/Presentation/Seats/ViewController/SeatsViewController.swift
@@ -31,6 +31,7 @@ extension SeatsViewController: UIAdaptivePresentationControllerDelegate {
             sheet.detents = [fraction]
             sheet.preferredCornerRadius = 20
         }
+        guestCountSheetViewController.isModalInPresentation = true
         
         self.present(guestCountSheetViewController, animated: true)
     }

--- a/CGV/Resource/Components/GuestCountButton.swift
+++ b/CGV/Resource/Components/GuestCountButton.swift
@@ -11,21 +11,30 @@ import Then
 import SnapKit
 
 final class GuestCountButton: UIView {
+    
+    // MARK: - Property
+
     static let defaultWidth: CGFloat = 100
+    
     static let defaultHeight: CGFloat = 42
     
+    // MARK: - UIComponent
+
     private let countView = UIView()
     
-    private let minusButton = UIButton()
+    let minusButton = UIButton()
     
-    private let plusButton = UIButton()
+    let plusButton = UIButton()
     
-    private let countLabel = UILabel()
+    let countLabel = UILabel()
+    
+    // MARK: - Initializer
     
     init(count: Int = 0) {
         super.init(frame: .zero)
         
         setCountLabel(count: count)
+        setAction()
         setStyle()
         setUI()
         setLayout()
@@ -34,6 +43,7 @@ final class GuestCountButton: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        setAction()
         setStyle()
         setUI()
         setLayout()
@@ -42,11 +52,14 @@ final class GuestCountButton: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
+        setAction()
         setStyle()
         setUI()
         setLayout()
     }
     
+    // MARK: - Function
+
     private func setCountLabel(count: Int) {
         countLabel.setText(
             count.description,
@@ -56,7 +69,38 @@ final class GuestCountButton: UIView {
         )
     }
     
-    private func setStyle() {
+    // MARK: - Action
+    
+    private func setAction() {
+        minusButton.addTarget(self, action: #selector(minusButtonDidTap), for: .touchUpInside)
+        plusButton.addTarget(self, action: #selector(plusButtonDidTap), for: .touchUpInside)
+    }
+    
+    @objc
+    private func minusButtonDidTap() {
+        guard let countText = countLabel.text else { return }
+        guard let count = Int(countText) else { return }
+        
+        if (count - 1) >= 0 && (count - 1) <= 8 {
+            countLabel.updateText((count - 1).description)
+        }
+    }
+    
+    @objc
+    private func plusButtonDidTap() {
+        guard let countText = countLabel.text else { return }
+        guard let count = Int(countText) else { return }
+        
+        if (count + 1) >= 0 && (count + 1) <= 8 {
+            countLabel.updateText((count + 1).description)
+        }
+    }
+}
+
+// MARK: - UISetting
+
+private extension GuestCountButton {
+    func setStyle() {
         backgroundColor = .cgvG200
         layer.cornerRadius = 8
         
@@ -74,11 +118,11 @@ final class GuestCountButton: UIView {
         }
     }
     
-    private func setUI() {
+    func setUI() {
         addSubviews(countView, countLabel, minusButton, plusButton)
     }
     
-    private func setLayout() {
+    func setLayout() {
         countView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.centerY.equalToSuperview()

--- a/CGV/Resource/Components/GuestCountButton.swift
+++ b/CGV/Resource/Components/GuestCountButton.swift
@@ -18,6 +18,10 @@ final class GuestCountButton: UIView {
     
     static let defaultHeight: CGFloat = 42
     
+    var currentCount: Int {
+        return Int(countLabel.text ?? "0") ?? 0
+    }
+    
     // MARK: - UIComponent
 
     private let countView = UIView()

--- a/CGV/Resource/Extensions/UILabel+.swift
+++ b/CGV/Resource/Extensions/UILabel+.swift
@@ -23,4 +23,12 @@ extension UILabel {
             numberOfLines = 0
         }
     }
+    
+    func updateText(_ text: String?) {
+        guard let currentAttributes = attributedText?.attributes(at: 0, effectiveRange: nil) else {
+            self.text = text
+            return
+        }
+        attributedText = NSAttributedString(string: text ?? " ", attributes: currentAttributes)
+    }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #14

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 각 버튼의 minus 버튼을 누르면 count 값이 1씩 감소하고, plus 버튼을 누르면 1씩 증가합니다.
- 이때 각 버튼의 count 값은 0보다 작을 수 없으며, 8보다 클 수도 없습니다. (조건에 맞지 않는 경우 클릭이 안 됩니다! 디자인 단에서 토스트 메시지와 같은 UI 에러 처리를 제공하지 않아 이 부분은 따로 구현하지 않았습니다.)
- 모든 버튼의 count 값의 합은 8을 초과할 수 없습니다. 따라서 모든 버튼의 count 값의 합이 1 이상 8 이하일 때 좌석 선택 버튼이 활성화됩니다.
- 활성화된 좌석 선택 버튼을 누르면 모달이 닫힙니다.
- 모달의 배경을 클릭하여 모달이 닫히는 제스쳐를 막았습니다.

|    구현 내용    |   IPhone 13 mini   |
| :-------------: | :----------: |
| 각 버튼의 최소최대 값 | <img src = "https://github.com/user-attachments/assets/4262d609-7e44-4979-923f-b72138b4316d" width ="250"> |
| 좌석선택 버튼 활성화 로직 | <img src = "https://github.com/user-attachments/assets/04e97781-0b98-440b-ac29-43621e53c939" width ="250"> |
| 좌석선택 버튼 화면 연결 | <img src = "https://github.com/user-attachments/assets/91a530c8-306c-487f-a23d-caaaee664538" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### updateText 익스텐션!

- UI에서 텍스트 스타일을 다 잡아뒀는데 서버 통신, 이벤트로 인한 값 변경 등의 사유로 레이블의 텍스트를 업데이트해야하는 경우 현재는 setText 메서드로 다시 스타일까지 함께 잡아줘야 하는 번거로움이 있습니다.
- UILabel의 updateText 메서드를 통해 text 값만 입력해도 기존의 스타일이 유지될 수 있도록 하였습니다! 해당 PR이 머지되면 여러분도 사용 가능하십니다 ㅋㅋ!

<details>
<summary>UILabel+</summary>

```swift
func updateText(_ text: String?) {
    guard let currentAttributes = attributedText?.attributes(at: 0, effectiveRange: nil) else {
        self.text = text
        return
    }
    attributedText = NSAttributedString(string: text ?? " ", attributes: currentAttributes)
}
```
</details>

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- updateText 익스텐션의 사용 이유와 예시에 대하여 데일리 스크럼 시간을 활용해 자세히 설명드리겠습니다!
- 뒤로 가기 버튼의 경우 모든 UI를 구현한 뒤 화면 연결이 필요합니다!
- 그 외의 궁금한 점이 있다면 편하게 코멘트 남겨주세요!