### PR TITLE
[feat] 홈 화면 예매율, myCGV, 푸터, 페이지네이션

### DIFF
--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		003919E62CEDE81C005B7C43 /* TopTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */; };
 		0060567F2CEC6C9000482BEC /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0060567E2CEC6C9000482BEC /* HomeView.swift */; };
 		00805C6C2CEF242D0016C6F7 /* ReserveRateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */; };
+		00805C702CEFAEC90016C6F7 /* MyCGVCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */; };
 		00AE2A862CEE3A530024CE6C /* MidTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */; };
 		00AE2A882CEE3D5A0024CE6C /* MidTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A872CEE3D5A0024CE6C /* MidTabBarCell.swift */; };
 		00C774282CEB98830020F5BA /* MidHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C774272CEB98830020F5BA /* MidHeaderView.swift */; };
@@ -69,6 +70,7 @@
 		003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabBarCell.swift; sourceTree = "<group>"; };
 		0060567E2CEC6C9000482BEC /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReserveRateCell.swift; sourceTree = "<group>"; };
+		00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCGVCell.swift; sourceTree = "<group>"; };
 		00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarView.swift; sourceTree = "<group>"; };
 		00AE2A872CEE3D5A0024CE6C /* MidTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarCell.swift; sourceTree = "<group>"; };
 		00C774272CEB98830020F5BA /* MidHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidHeaderView.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				00C7742D2CEB9BA10020F5BA /* MovieChartCell.swift */,
 				00C7742B2CEB9A5E0020F5BA /* BigImageCell.swift */,
 				00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */,
+				00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -479,6 +482,7 @@
 				A36349362CEC2DAF003B5322 /* GuestCountSheetViewController.swift in Sources */,
 				A36349282CEA7D89003B5322 /* ReuseIdentifable.swift in Sources */,
 				A36349162CEA6936003B5322 /* NSAttributedString+.swift in Sources */,
+				00805C702CEFAEC90016C6F7 /* MyCGVCell.swift in Sources */,
 				00805C6C2CEF242D0016C6F7 /* ReserveRateCell.swift in Sources */,
 				00C774302CEBAF7F0020F5BA /* HomeItem.swift in Sources */,
 				A36348F52CE9CF45003B5322 /* TimeViewController.swift in Sources */,

--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0030771B2CF4CB5B008F7BDF /* MidTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0030771A2CF4CB5B008F7BDF /* MidTabBarViewController.swift */; };
 		0032F4B92CEDC4D500F14451 /* TopHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032F4B82CEDC4D500F14451 /* TopHeaderView.swift */; };
 		0032F4BB2CEDDB4800F14451 /* TopHeaderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032F4BA2CEDDB4800F14451 /* TopHeaderViewCell.swift */; };
 		003919E62CEDE81C005B7C43 /* TopTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */; };
@@ -67,6 +68,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0030771A2CF4CB5B008F7BDF /* MidTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarViewController.swift; sourceTree = "<group>"; };
 		0032F4B82CEDC4D500F14451 /* TopHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopHeaderView.swift; sourceTree = "<group>"; };
 		0032F4BA2CEDDB4800F14451 /* TopHeaderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopHeaderViewCell.swift; sourceTree = "<group>"; };
 		003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabBarCell.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				A36348DF2CE8EB85003B5322 /* HomeViewController.swift */,
+				0030771A2CF4CB5B008F7BDF /* MidTabBarViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 				A36349322CEC2D6B003B5322 /* SeatsView.swift in Sources */,
 				A36349232CEA7D06003B5322 /* BaseCollectionViewCell.swift in Sources */,
 				00C7742E2CEB9BA10020F5BA /* MovieChartCell.swift in Sources */,
+				0030771B2CF4CB5B008F7BDF /* MidTabBarViewController.swift in Sources */,
 				00BF992C2CF0B69D000920A8 /* ProgressShareCell.swift in Sources */,
 				AD9263F62CEC838600F63581 /* RegionType.swift in Sources */,
 				A36349182CEA6E87003B5322 /* UILabel+.swift in Sources */,

--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		00AE2A862CEE3A530024CE6C /* MidTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */; };
 		00AE2A882CEE3D5A0024CE6C /* MidTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A872CEE3D5A0024CE6C /* MidTabBarCell.swift */; };
 		00BF992A2CF05311000920A8 /* BottomFooterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BF99292CF05311000920A8 /* BottomFooterCell.swift */; };
+		00BF992C2CF0B69D000920A8 /* ProgressShareCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BF992B2CF0B69D000920A8 /* ProgressShareCell.swift */; };
 		00C774282CEB98830020F5BA /* MidHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C774272CEB98830020F5BA /* MidHeaderView.swift */; };
 		00C7742A2CEB99C40020F5BA /* BannerImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C774292CEB99C40020F5BA /* BannerImageCell.swift */; };
 		00C7742C2CEB9A5E0020F5BA /* BigImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C7742B2CEB9A5E0020F5BA /* BigImageCell.swift */; };
@@ -75,6 +76,7 @@
 		00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarView.swift; sourceTree = "<group>"; };
 		00AE2A872CEE3D5A0024CE6C /* MidTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarCell.swift; sourceTree = "<group>"; };
 		00BF99292CF05311000920A8 /* BottomFooterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomFooterCell.swift; sourceTree = "<group>"; };
+		00BF992B2CF0B69D000920A8 /* ProgressShareCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressShareCell.swift; sourceTree = "<group>"; };
 		00C774272CEB98830020F5BA /* MidHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidHeaderView.swift; sourceTree = "<group>"; };
 		00C774292CEB99C40020F5BA /* BannerImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageCell.swift; sourceTree = "<group>"; };
 		00C7742B2CEB9A5E0020F5BA /* BigImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigImageCell.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */,
 				00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */,
 				00BF99292CF05311000920A8 /* BottomFooterCell.swift */,
+				00BF992B2CF0B69D000920A8 /* ProgressShareCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				A36349322CEC2D6B003B5322 /* SeatsView.swift in Sources */,
 				A36349232CEA7D06003B5322 /* BaseCollectionViewCell.swift in Sources */,
 				00C7742E2CEB9BA10020F5BA /* MovieChartCell.swift in Sources */,
+				00BF992C2CF0B69D000920A8 /* ProgressShareCell.swift in Sources */,
 				AD9263F62CEC838600F63581 /* RegionType.swift in Sources */,
 				A36349182CEA6E87003B5322 /* UILabel+.swift in Sources */,
 				A36348E02CE8EB85003B5322 /* HomeViewController.swift in Sources */,

--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		00805C702CEFAEC90016C6F7 /* MyCGVCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */; };
 		00AE2A862CEE3A530024CE6C /* MidTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */; };
 		00AE2A882CEE3D5A0024CE6C /* MidTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A872CEE3D5A0024CE6C /* MidTabBarCell.swift */; };
+		00BF992A2CF05311000920A8 /* BottomFooterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BF99292CF05311000920A8 /* BottomFooterCell.swift */; };
 		00C774282CEB98830020F5BA /* MidHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C774272CEB98830020F5BA /* MidHeaderView.swift */; };
 		00C7742A2CEB99C40020F5BA /* BannerImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C774292CEB99C40020F5BA /* BannerImageCell.swift */; };
 		00C7742C2CEB9A5E0020F5BA /* BigImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C7742B2CEB9A5E0020F5BA /* BigImageCell.swift */; };
@@ -73,6 +74,7 @@
 		00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCGVCell.swift; sourceTree = "<group>"; };
 		00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarView.swift; sourceTree = "<group>"; };
 		00AE2A872CEE3D5A0024CE6C /* MidTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarCell.swift; sourceTree = "<group>"; };
+		00BF99292CF05311000920A8 /* BottomFooterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomFooterCell.swift; sourceTree = "<group>"; };
 		00C774272CEB98830020F5BA /* MidHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidHeaderView.swift; sourceTree = "<group>"; };
 		00C774292CEB99C40020F5BA /* BannerImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageCell.swift; sourceTree = "<group>"; };
 		00C7742B2CEB9A5E0020F5BA /* BigImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigImageCell.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 				00C7742B2CEB9A5E0020F5BA /* BigImageCell.swift */,
 				00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */,
 				00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */,
+				00BF99292CF05311000920A8 /* BottomFooterCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -473,6 +476,7 @@
 				00AE2A882CEE3D5A0024CE6C /* MidTabBarCell.swift in Sources */,
 				00C7742A2CEB99C40020F5BA /* BannerImageCell.swift in Sources */,
 				A36349042CEA49D4003B5322 /* UIView+.swift in Sources */,
+				00BF992A2CF05311000920A8 /* BottomFooterCell.swift in Sources */,
 				00AE2A862CEE3A530024CE6C /* MidTabBarView.swift in Sources */,
 				A36348B82CE8E937003B5322 /* AppDelegate.swift in Sources */,
 				AD9263F42CEC588200F63581 /* UnderlineSegmentedControl.swift in Sources */,

--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0030771B2CF4CB5B008F7BDF /* MidTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0030771A2CF4CB5B008F7BDF /* MidTabBarViewController.swift */; };
+		0030771D2CF4EF25008F7BDF /* MidGrayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0030771C2CF4EF25008F7BDF /* MidGrayView.swift */; };
 		0032F4B92CEDC4D500F14451 /* TopHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032F4B82CEDC4D500F14451 /* TopHeaderView.swift */; };
 		0032F4BB2CEDDB4800F14451 /* TopHeaderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032F4BA2CEDDB4800F14451 /* TopHeaderViewCell.swift */; };
 		003919E62CEDE81C005B7C43 /* TopTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */; };
@@ -69,6 +70,7 @@
 
 /* Begin PBXFileReference section */
 		0030771A2CF4CB5B008F7BDF /* MidTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarViewController.swift; sourceTree = "<group>"; };
+		0030771C2CF4EF25008F7BDF /* MidGrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidGrayView.swift; sourceTree = "<group>"; };
 		0032F4B82CEDC4D500F14451 /* TopHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopHeaderView.swift; sourceTree = "<group>"; };
 		0032F4BA2CEDDB4800F14451 /* TopHeaderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopHeaderViewCell.swift; sourceTree = "<group>"; };
 		003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabBarCell.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				0032F4B82CEDC4D500F14451 /* TopHeaderView.swift */,
 				00C774272CEB98830020F5BA /* MidHeaderView.swift */,
 				00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */,
+				0030771C2CF4EF25008F7BDF /* MidGrayView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -479,6 +482,7 @@
 				0032F4B92CEDC4D500F14451 /* TopHeaderView.swift in Sources */,
 				A36349062CEA4A70003B5322 /* UIStackView+.swift in Sources */,
 				00C7742C2CEB9A5E0020F5BA /* BigImageCell.swift in Sources */,
+				0030771D2CF4EF25008F7BDF /* MidGrayView.swift in Sources */,
 				00AE2A882CEE3D5A0024CE6C /* MidTabBarCell.swift in Sources */,
 				00C7742A2CEB99C40020F5BA /* BannerImageCell.swift in Sources */,
 				A36349042CEA49D4003B5322 /* UIView+.swift in Sources */,

--- a/CGV/Presentation/Home/Model/HomeItem.swift
+++ b/CGV/Presentation/Home/Model/HomeItem.swift
@@ -14,6 +14,7 @@ enum HomeSectionType: Int, CaseIterable {
     case movieChart
     case special
     case specialRate
+    case myCGV
     case todayCGV
     case todayRate
 }
@@ -56,7 +57,15 @@ extension HomeSectionType {
         case .topHeader, .topTabBar, .banner, .specialRate, .todayRate: return ""
         case .movieChart: return "무비 차트"
         case .special: return "특별관"
+        case .myCGV: return "나의 CGV"
         case .todayCGV: return "오늘의 CGV"
+        }
+    }
+    
+    var headerSubtitle: String {
+        switch self {
+        case .myCGV: return "자세히 보기"
+        default: return "전체보기"
         }
     }
     
@@ -205,6 +214,26 @@ extension HomeItem {
             title: "베놈 : 라스트 댄스",
             image: UIImage(resource: .imgHomeSmallposter3),
             rate: "예매율 1.3%"
+        ),
+        
+        // My CGV section items
+        HomeItem(
+            section: .myCGV,
+            title: "내가 본 영화",
+            image: UIImage(resource: .icHomeMovie),
+            rate: "9편"
+        ),
+        HomeItem(
+            section: .myCGV,
+            title: "기대되는 영화",
+            image: UIImage(resource: .icHomeLike),
+            rate: "2편"
+        ),
+        HomeItem(
+            section: .myCGV,
+            title: "내가 쓴 리뷰",
+            image: UIImage(resource: .icHomePen),
+            rate: "1편"
         ),
         
         // Today CGV section items

--- a/CGV/Presentation/Home/Model/HomeItem.swift
+++ b/CGV/Presentation/Home/Model/HomeItem.swift
@@ -57,7 +57,14 @@ struct HomeItem: Hashable {
 extension HomeSectionType {
     var headerTitle: String {
         switch self {
-        case .topHeader, .topTabBar, .banner, .specialRate, .todayRate, .bottomfooter, .specialProgress, .todayProgress: return ""
+        case .topHeader,
+             .topTabBar,
+             .banner,
+             .specialRate,
+             .todayRate,
+             .bottomfooter,
+             .specialProgress,
+             .todayProgress: return ""
         case .movieChart: return "무비 차트"
         case .special: return "특별관"
         case .myCGV: return "나의 CGV"

--- a/CGV/Presentation/Home/Model/HomeItem.swift
+++ b/CGV/Presentation/Home/Model/HomeItem.swift
@@ -13,9 +13,11 @@ enum HomeSectionType: Int, CaseIterable {
     case banner
     case movieChart
     case special
+    case specialProgress
     case specialRate
     case myCGV
     case todayCGV
+    case todayProgress
     case todayRate
     case bottomfooter
 }
@@ -55,7 +57,7 @@ struct HomeItem: Hashable {
 extension HomeSectionType {
     var headerTitle: String {
         switch self {
-        case .topHeader, .topTabBar, .banner, .specialRate, .todayRate, .bottomfooter: return ""
+        case .topHeader, .topTabBar, .banner, .specialRate, .todayRate, .bottomfooter, .specialProgress, .todayProgress: return ""
         case .movieChart: return "무비 차트"
         case .special: return "특별관"
         case .myCGV: return "나의 CGV"
@@ -199,6 +201,10 @@ extension HomeItem {
             image: UIImage(resource: .imgHomeImax4)
         ),
         HomeItem(
+            section: .specialProgress,
+            title: ""
+        ),
+        HomeItem(
             section: .specialRate,
             title: "글래디에이터 II",
             image: UIImage(resource: .imgHomeSmallposter1),
@@ -257,6 +263,10 @@ extension HomeItem {
             section: .todayCGV,
             title: "",
             image: UIImage(resource: .imgHomeHot4)
+        ),
+        HomeItem(
+            section: .todayProgress,
+            title: ""
         ),
         HomeItem(
             section: .todayRate,

--- a/CGV/Presentation/Home/Model/HomeItem.swift
+++ b/CGV/Presentation/Home/Model/HomeItem.swift
@@ -9,12 +9,13 @@ import UIKit
 
 enum HomeSectionType: Int, CaseIterable {
     case topHeader
-    case topTapBar
+    case topTabBar
     case banner
     case movieChart
     case special
+    case specialRate
     case todayCGV
-//    case reserveRate
+    case todayRate
 }
 
 struct HomeItem: Hashable {
@@ -25,15 +26,15 @@ struct HomeItem: Hashable {
     let preEgg: String?
     let dDay: String?
     let image: UIImage?
-//    let rate: String?
+    let rate: String?
     
     init(section: HomeSectionType,
          title: String,
          ageLimit: UIImage? = nil,
          preEgg: String? = nil,
          dDay: String? = nil,
-         image: UIImage? = nil
-//         rate: String? = nil
+         image: UIImage? = nil,
+         rate: String? = nil
     ) {
         self.section = section
         self.title = title
@@ -41,7 +42,7 @@ struct HomeItem: Hashable {
         self.preEgg = preEgg
         self.dDay = dDay
         self.image = image
-//        self.rate = rate
+        self.rate = rate
     }
     
     func hash(into hasher: inout Hasher) {
@@ -52,7 +53,7 @@ struct HomeItem: Hashable {
 extension HomeSectionType {
     var headerTitle: String {
         switch self {
-        case .topHeader, .topTapBar, .banner: return ""
+        case .topHeader, .topTabBar, .banner, .specialRate, .todayRate: return ""
         case .movieChart: return "무비 차트"
         case .special: return "특별관"
         case .todayCGV: return "오늘의 CGV"
@@ -187,24 +188,24 @@ extension HomeItem {
             title: "",
             image: UIImage(resource: .imgHomeImax4)
         ),
-//        HomeItem(
-//            section: .reserveRate,
-//            title: "글래디에이터 II",
-//            image: UIImage(resource: .imgHomeSmallposter1),
-//            rate: "예매율 17.3%"
-//        ),
-//        HomeItem(
-//            section: .reserveRate,
-//            title: "위키드",
-//            image: UIImage(resource: .imgHomeSmallposter2),
-//            rate: "예매율 16.5%"
-//        ),
-//        HomeItem(
-//            section: .reserveRate,
-//            title: "베놈 : 라스트 댄스",
-//            image: UIImage(resource: .imgHomeSmallposter3),
-//            rate: "예매율 1.3%"
-//        ),
+        HomeItem(
+            section: .specialRate,
+            title: "글래디에이터 II",
+            image: UIImage(resource: .imgHomeSmallposter1),
+            rate: "예매율 17.3%"
+        ),
+        HomeItem(
+            section: .specialRate,
+            title: "위키드",
+            image: UIImage(resource: .imgHomeSmallposter2),
+            rate: "예매율 16.5%"
+        ),
+        HomeItem(
+            section: .specialRate,
+            title: "베놈 : 라스트 댄스",
+            image: UIImage(resource: .imgHomeSmallposter3),
+            rate: "예매율 1.3%"
+        ),
         
         // Today CGV section items
         HomeItem(
@@ -227,24 +228,24 @@ extension HomeItem {
             title: "",
             image: UIImage(resource: .imgHomeHot4)
         ),
-//        HomeItem(
-//            section: .reserveRate,
-//            title: "아마존 활명수",
-//            image: UIImage(resource: .imgHomeSmallposter4),
-//            rate: "예매율 1.2%"
-//        ),
-//        HomeItem(
-//            section: .reserveRate,
-//            title: "위키드",
-//            image: UIImage(resource: .imgHomeSmallposter2),
-//            rate: "예매율 18.5%"
-//        ),
-//        HomeItem(
-//            section: .reserveRate,
-//            title: "아메바 소녀들과 학교 괴담",
-//            image: UIImage(resource: .imgHomeSmallposter5),
-//            rate: "예매율 1.1%"
-//        ),
+        HomeItem(
+            section: .todayRate,
+            title: "아마존 활명수",
+            image: UIImage(resource: .imgHomeSmallposter4),
+            rate: "예매율 1.2%"
+        ),
+        HomeItem(
+            section: .todayRate,
+            title: "위키드",
+            image: UIImage(resource: .imgHomeSmallposter2),
+            rate: "예매율 18.5%"
+        ),
+        HomeItem(
+            section: .todayRate,
+            title: "아메바 소녀들과 학교 괴담",
+            image: UIImage(resource: .imgHomeSmallposter5),
+            rate: "예매율 1.1%"
+        ),
     ]
 }
 

--- a/CGV/Presentation/Home/Model/HomeItem.swift
+++ b/CGV/Presentation/Home/Model/HomeItem.swift
@@ -17,6 +17,7 @@ enum HomeSectionType: Int, CaseIterable {
     case myCGV
     case todayCGV
     case todayRate
+    case bottomfooter
 }
 
 struct HomeItem: Hashable {
@@ -54,7 +55,7 @@ struct HomeItem: Hashable {
 extension HomeSectionType {
     var headerTitle: String {
         switch self {
-        case .topHeader, .topTabBar, .banner, .specialRate, .todayRate: return ""
+        case .topHeader, .topTabBar, .banner, .specialRate, .todayRate, .bottomfooter: return ""
         case .movieChart: return "무비 차트"
         case .special: return "특별관"
         case .myCGV: return "나의 CGV"
@@ -275,6 +276,14 @@ extension HomeItem {
             image: UIImage(resource: .imgHomeSmallposter5),
             rate: "예매율 1.1%"
         ),
+        
+        
+        // BottomFooter Section Items
+        HomeItem(
+            section: .bottomfooter,
+            title: "CJ CGV (주)",
+            image: UIImage(resource: .icHomeArrowDown)
+        )
     ]
 }
 

--- a/CGV/Presentation/Home/View/Cell/BannerImageCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BannerImageCell.swift
@@ -11,8 +11,13 @@ import SnapKit
 import Then
 
 final class BannerImageCell: BaseCollectionViewCell {
+    
+    // MARK: - Property
+    
     private let bannerImageView = UIImageView()
     private let countLabel = UILabel()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         bannerImageView.do {
@@ -45,6 +50,8 @@ final class BannerImageCell: BaseCollectionViewCell {
             $0.height.equalTo(18)
         }
     }
+    
+    // MARK: - Configure
     
     func configure(image: UIImage?) {
         bannerImageView.image = image

--- a/CGV/Presentation/Home/View/Cell/BigImageCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BigImageCell.swift
@@ -11,7 +11,12 @@ import SnapKit
 import Then
 
 final class BigImageCell: BaseCollectionViewCell {
+    
+    // MARK: - Property
+    
     private let bigImageView = UIImageView()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         bigImageView.do {
@@ -31,6 +36,8 @@ final class BigImageCell: BaseCollectionViewCell {
             $0.width.equalToSuperview()
         }
     }
+    
+    // MARK: - Configure
     
     func configure(image: UIImage?) {
         bigImageView.image = image

--- a/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class BottomFooterCell: BaseCollectionViewCell {
     
+    // MARK: - Property
+    
     private let titleLabel = UILabel()
     private let iconImageView = UIImageView()
     private let buttonStackView = UIStackView()
@@ -19,6 +21,8 @@ class BottomFooterCell: BaseCollectionViewCell {
     private let firstDivider = UILabel()
     private let secondDivider = UILabel()
     private let thirdDivider = UILabel()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         self.backgroundColor = UIColor(resource: .cgvG100)
@@ -132,6 +136,8 @@ class BottomFooterCell: BaseCollectionViewCell {
             $0.centerY.equalToSuperview()
         }
     }
+    
+    // MARK: - Configure
     
     func configure(title: String, image: UIImage) {
         titleLabel.setText(title, style: Malgun.head1, color: .cgvBlack)

--- a/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
@@ -1,0 +1,141 @@
+//
+//  BottomFooterCell.swift
+//  CGV
+//
+//  Created by 김송희 on 11/22/24.
+//
+
+import UIKit
+
+class BottomFooterCell: BaseCollectionViewCell {
+    
+    private let titleLabel = UILabel()
+    private let iconImageView = UIImageView()
+    private let buttonStackView = UIStackView()
+    private let userRuleButton = UIButton()
+    private let dataRuleButton = UIButton()
+    private let locationRuleButton = UIButton()
+    private let lawRuleButton = UIButton()
+    private let firstDivider = UILabel()
+    private let secondDivider = UILabel()
+    private let thirdDivider = UILabel()
+    
+    override func setStyle() {
+        self.backgroundColor = UIColor(resource: .cgvG100)
+        
+        titleLabel.do {
+            $0.setText(style: Malgun.head1, color: .cgvBlack)
+        }
+        
+        iconImageView.do {
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        buttonStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .equalSpacing
+            $0.spacing = 7
+            $0.alignment = .center
+        }
+        
+        userRuleButton.do {
+            $0.setTitle("이용약관", style: Kopub.body1, color: .cgvG800)
+            $0.backgroundColor = .clear
+        }
+        
+        dataRuleButton.do {
+            $0.setTitle("개인정보 처리방침", style: Kopub.head1, color: .cgvG800)
+            $0.backgroundColor = .clear
+        }
+        
+        locationRuleButton.do {
+            $0.setTitle("위치기반서비스 이용약관", style: Kopub.body1, color: .cgvG800)
+            $0.backgroundColor = .clear
+        }
+        
+        lawRuleButton.do {
+            $0.setTitle("법적고지", style: Kopub.body1, color: .cgvG800)
+            $0.backgroundColor = .clear
+        }
+        
+        firstDivider.do {
+            $0.backgroundColor = UIColor(resource: .cgvG500)
+        }
+        
+        secondDivider.do {
+            $0.backgroundColor = UIColor(resource: .cgvG500)
+        }
+        
+        thirdDivider.do {
+            $0.backgroundColor = UIColor(resource: .cgvG500)
+        }
+    }
+    
+    override func setUI() {
+        addSubviews(titleLabel, iconImageView, buttonStackView)
+        buttonStackView.addArrangedSubviews(userRuleButton, firstDivider, dataRuleButton, secondDivider, locationRuleButton, thirdDivider, lawRuleButton)
+    }
+    
+    override func setLayout() {
+        titleLabel.snp.makeConstraints{
+            $0.top.equalToSuperview().inset(33)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        iconImageView.snp.makeConstraints{
+            $0.top.equalTo(titleLabel.snp.top).offset(7)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
+            $0.size.equalTo(18)
+        }
+        
+        buttonStackView.snp.makeConstraints{
+            $0.top.equalTo(titleLabel.snp.bottom).offset(11)
+            $0.leading.equalToSuperview().inset(20)
+            $0.height.equalTo(16)
+        }
+        
+        userRuleButton.snp.makeConstraints{
+            $0.width.equalTo(35)
+            $0.height.equalTo(16)
+        }
+        
+        dataRuleButton.snp.makeConstraints{
+            $0.width.equalTo(73)
+            $0.height.equalTo(16)
+        }
+        
+        locationRuleButton.snp.makeConstraints{
+            $0.width.equalTo(99)
+            $0.height.equalTo(16)
+        }
+        
+        lawRuleButton.snp.makeConstraints{
+            $0.width.equalTo(35)
+            $0.height.equalTo(16)
+        }
+        
+        firstDivider.snp.makeConstraints{
+            $0.width.equalTo(1)
+            $0.height.equalTo(8)
+            $0.centerY.equalToSuperview()
+        }
+        
+        secondDivider.snp.makeConstraints{
+            $0.width.equalTo(1)
+            $0.height.equalTo(8)
+            $0.centerY.equalToSuperview()
+        }
+        
+        thirdDivider.snp.makeConstraints{
+            $0.width.equalTo(1)
+            $0.height.equalTo(8)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    func configure(title: String, image: UIImage) {
+        titleLabel.setText(title, style: Malgun.head1, color: .cgvBlack)
+        iconImageView.image = image
+    }
+    
+}

--- a/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
@@ -39,7 +39,7 @@ final class BottomFooterCell: BaseCollectionViewCell {
             $0.axis = .horizontal
             $0.distribution = .equalSpacing
             $0.spacing = 7
-            $0.alignment = .center
+            $0.alignment = .top
         }
         
         userRuleButton.do {
@@ -106,42 +106,37 @@ final class BottomFooterCell: BaseCollectionViewCell {
             $0.height.equalTo(16)
         }
         
-//        userRuleButton.snp.makeConstraints{
-//            $0.width.equalTo(35)
-//            $0.height.equalTo(16)
-//        }
-//        
-//        dataRuleButton.snp.makeConstraints{
-//            $0.width.equalTo(73)
-//            $0.height.equalTo(16)
-//        }
-//        
-//        locationRuleButton.snp.makeConstraints{
-//            $0.width.equalTo(99)
-//            $0.height.equalTo(16)
-//        }
-//        
-//        lawRuleButton.snp.makeConstraints{
-//            $0.width.equalTo(35)
-//            $0.height.equalTo(16)
-//        }
-        
         firstDivider.snp.makeConstraints{
             $0.width.equalTo(1)
             $0.height.equalTo(8)
-            $0.centerY.equalToSuperview()
+            $0.top.equalToSuperview().inset(3)
+            $0.bottom.equalToSuperview().inset(5)
         }
         
         secondDivider.snp.makeConstraints{
             $0.width.equalTo(1)
             $0.height.equalTo(8)
-            $0.centerY.equalToSuperview()
         }
         
         thirdDivider.snp.makeConstraints{
             $0.width.equalTo(1)
             $0.height.equalTo(8)
-            $0.centerY.equalToSuperview()
+        }
+        
+        userRuleButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview().offset(-1)
+        }
+        
+        dataRuleButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview().offset(-2)
+        }
+        
+        locationRuleButton.snp.makeConstraints{
+            $0.centerY.equalToSuperview().offset(-1)
+        }
+        
+        lawRuleButton.snp.makeConstraints{
+            $0.centerY.equalToSuperview().offset(-1)
         }
     }
     
@@ -151,5 +146,4 @@ final class BottomFooterCell: BaseCollectionViewCell {
         titleLabel.updateText(title)
         iconImageView.image = image
     }
-    
 }

--- a/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BottomFooterCell: BaseCollectionViewCell {
+final class BottomFooterCell: BaseCollectionViewCell {
     
     // MARK: - Property
     
@@ -77,7 +77,15 @@ class BottomFooterCell: BaseCollectionViewCell {
     
     override func setUI() {
         addSubviews(titleLabel, iconImageView, buttonStackView)
-        buttonStackView.addArrangedSubviews(userRuleButton, firstDivider, dataRuleButton, secondDivider, locationRuleButton, thirdDivider, lawRuleButton)
+        buttonStackView.addArrangedSubviews(
+            userRuleButton,
+            firstDivider,
+            dataRuleButton,
+            secondDivider,
+            locationRuleButton,
+            thirdDivider,
+            lawRuleButton
+        )
     }
     
     override func setLayout() {
@@ -98,25 +106,25 @@ class BottomFooterCell: BaseCollectionViewCell {
             $0.height.equalTo(16)
         }
         
-        userRuleButton.snp.makeConstraints{
-            $0.width.equalTo(35)
-            $0.height.equalTo(16)
-        }
-        
-        dataRuleButton.snp.makeConstraints{
-            $0.width.equalTo(73)
-            $0.height.equalTo(16)
-        }
-        
-        locationRuleButton.snp.makeConstraints{
-            $0.width.equalTo(99)
-            $0.height.equalTo(16)
-        }
-        
-        lawRuleButton.snp.makeConstraints{
-            $0.width.equalTo(35)
-            $0.height.equalTo(16)
-        }
+//        userRuleButton.snp.makeConstraints{
+//            $0.width.equalTo(35)
+//            $0.height.equalTo(16)
+//        }
+//        
+//        dataRuleButton.snp.makeConstraints{
+//            $0.width.equalTo(73)
+//            $0.height.equalTo(16)
+//        }
+//        
+//        locationRuleButton.snp.makeConstraints{
+//            $0.width.equalTo(99)
+//            $0.height.equalTo(16)
+//        }
+//        
+//        lawRuleButton.snp.makeConstraints{
+//            $0.width.equalTo(35)
+//            $0.height.equalTo(16)
+//        }
         
         firstDivider.snp.makeConstraints{
             $0.width.equalTo(1)
@@ -140,7 +148,7 @@ class BottomFooterCell: BaseCollectionViewCell {
     // MARK: - Configure
     
     func configure(title: String, image: UIImage) {
-        titleLabel.setText(title, style: Malgun.head1, color: .cgvBlack)
+        titleLabel.updateText(title)
         iconImageView.image = image
     }
     

--- a/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
@@ -51,7 +51,11 @@ final class MidTabBarCell: BaseCollectionViewCell {
     // MARK: - Configure
     
     func configure(title: String, isSelected: Bool) {
-        tabNameLabel.setText(title, style: Kopub.body3, color: isSelected ? .cgvG900 : .cgvG600)
+        tabNameLabel.setText(
+            title,
+            style: Kopub.body3,
+            color: isSelected ? .cgvG900 : .cgvG600
+        )
         underlineView.backgroundColor = isSelected ? .black : .clear
     }
 }

--- a/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
@@ -12,8 +12,12 @@ import Then
 
 class MidTabBarCell: BaseCollectionViewCell {
     
+    // MARK: - Property
+    
     private let tabNameLabel = UILabel()
     private let underlineView = UIView()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         tabNameLabel.do {
@@ -43,6 +47,8 @@ class MidTabBarCell: BaseCollectionViewCell {
             $0.leading.equalToSuperview()
         }
     }
+    
+    // MARK: - Configure
     
     func configure(title: String, isSelected: Bool) {
         tabNameLabel.setText(title, style: Kopub.body3, color: isSelected ? .cgvG900 : .cgvG600)

--- a/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class MidTabBarCell: BaseCollectionViewCell {
+final class MidTabBarCell: BaseCollectionViewCell {
     
     // MARK: - Property
     

--- a/CGV/Presentation/Home/View/Cell/MovieChartCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MovieChartCell.swift
@@ -155,9 +155,9 @@ final class MovieChartCell: BaseCollectionViewCell {
         dDay: String
     ) {
         posterImageView.image = poster
-        titleLabel.setText(title, style: Kopub.head4, color: .cgvBlack, isSingleLine: true)
+        titleLabel.updateText(title)
         ageLimitImageView.image = ageLimit
-        preEggStatLabel.setText(preEgg, style: Kopub.head3, color: .cgvG800)
-        dDayLabel.setText(dDay, style: Kopub.head3, color: .cgvR400)
+        preEggStatLabel.updateText(preEgg)
+        dDayLabel.updateText(dDay)
     }
 }

--- a/CGV/Presentation/Home/View/Cell/MovieChartCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MovieChartCell.swift
@@ -11,6 +11,9 @@ import SnapKit
 import Then
 
 final class MovieChartCell: BaseCollectionViewCell {
+    
+    // MARK: - Property
+    
     private let posterImageView = UIImageView()
     
     private let firstStackView = UIStackView()
@@ -24,6 +27,8 @@ final class MovieChartCell: BaseCollectionViewCell {
     private let dDayLabel = UILabel()
     
     private let reserveButton = UIButton()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         posterImageView.do {
@@ -139,6 +144,8 @@ final class MovieChartCell: BaseCollectionViewCell {
             $0.height.equalTo(40)
         }
     }
+    
+    // MARK: - Configure
     
     func configure(
         poster: UIImage?,

--- a/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MyCGVCell: BaseCollectionViewCell {
+final class MyCGVCell: BaseCollectionViewCell {
     
     // MARK: - Property
     
@@ -68,8 +68,8 @@ class MyCGVCell: BaseCollectionViewCell {
     // MARK: - Configure
     
     func configure(title: String, rate: String, image: UIImage?) {
-        titleLabel.setText(title, style: Kopub.head4, color: .cgvG850)
-        rateLabel.setText(rate, style: Kopub.head4, color: .cgvG850)
+        titleLabel.updateText(title)
+        rateLabel.updateText(rate)
         iconView.image = image
     }
 }

--- a/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
@@ -9,10 +9,14 @@ import UIKit
 
 class MyCGVCell: BaseCollectionViewCell {
     
+    // MARK: - Property
+    
     private let underView = UIView()
     private let iconView = UIImageView()
     private let titleLabel = UILabel()
     private let rateLabel = UILabel()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         underView.do {
@@ -60,6 +64,8 @@ class MyCGVCell: BaseCollectionViewCell {
             $0.centerY.equalTo(iconView.snp.centerY)
         }
     }
+    
+    // MARK: - Configure
     
     func configure(title: String, rate: String, image: UIImage?) {
         titleLabel.setText(title, style: Kopub.head4, color: .cgvG850)

--- a/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
@@ -1,0 +1,69 @@
+//
+//  MyCGVCell.swift
+//  CGV
+//
+//  Created by 김송희 on 11/22/24.
+//
+
+import UIKit
+
+class MyCGVCell: BaseCollectionViewCell {
+    
+    private let underView = UIView()
+    private let iconView = UIImageView()
+    private let titleLabel = UILabel()
+    private let rateLabel = UILabel()
+    
+    override func setStyle() {
+        underView.do {
+            $0.backgroundColor = .cgvG200
+            $0.layer.cornerRadius = 8
+        }
+        
+        iconView.do {
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        titleLabel.do {
+            $0.setText(style: Kopub.head4, color: .cgvG850)
+        }
+        
+        rateLabel.do {
+            $0.setText(style: Kopub.head4, color: .cgvG850)
+        }
+    }
+    
+    override func setUI() {
+        addSubviews(underView, iconView, titleLabel, rateLabel)
+    }
+    
+    override func setLayout() {
+        underView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(335)
+            $0.height.equalTo(50)
+        }
+        
+        iconView.snp.makeConstraints{
+            $0.top.equalToSuperview().inset(11)
+            $0.leading.equalToSuperview().inset(13)
+            $0.size.equalTo(28)
+        }
+        
+        titleLabel.snp.makeConstraints{
+            $0.centerY.equalTo(iconView.snp.centerY)
+            $0.leading.equalTo(iconView.snp.trailing).offset(8)
+        }
+        
+        rateLabel.snp.makeConstraints{
+            $0.trailing.equalToSuperview().inset(11)
+            $0.centerY.equalTo(iconView.snp.centerY)
+        }
+    }
+    
+    func configure(title: String, rate: String, image: UIImage?) {
+        titleLabel.setText(title, style: Kopub.head4, color: .cgvG850)
+        rateLabel.setText(rate, style: Kopub.head4, color: .cgvG850)
+        iconView.image = image
+    }
+}

--- a/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
@@ -1,0 +1,77 @@
+//
+//  ProgressShareCell.swift
+//  CGV
+//
+//  Created by 김송희 on 11/22/24.
+//
+
+import UIKit
+
+class ProgressShareCell: BaseCollectionViewCell {
+    
+    private let progressStackView = UIStackView()
+    private let firstLabel = UILabel()
+    private let secondLabel = UILabel()
+    private let thirdLabel = UILabel()
+    private let fourthLabel = UILabel()
+    private let shareButton = UIButton()
+    
+    override func setStyle() {        
+        [firstLabel, secondLabel, thirdLabel, fourthLabel].forEach { label in
+            label.text = "●"
+            label.font = .systemFont(ofSize: 7, weight: .medium)
+            label.textAlignment = .center
+            label.textColor = UIColor(resource: .cgvG400)
+        }
+        
+        firstLabel.textColor = UIColor(resource: .cgvG700)
+        
+        progressStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 8
+            $0.alignment = .center
+        }
+        
+        shareButton.do {
+            $0.setImage(UIImage(resource: .icHomeShare), for: .normal)
+            $0.tintColor = .cgvBlack
+        }
+    }
+    
+    override func setUI() {
+        addSubviews(progressStackView, shareButton)
+        progressStackView.addArrangedSubviews(firstLabel, secondLabel, thirdLabel, fourthLabel)
+    }
+    
+    override func setLayout() {
+        progressStackView.snp.makeConstraints{
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        shareButton.snp.makeConstraints{
+            $0.size.equalTo(30)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    func configure(to index: Int) {
+        [firstLabel, secondLabel, thirdLabel, fourthLabel].forEach {
+            $0.textColor = UIColor(resource: .cgvG400)
+        }
+        
+        switch index {
+        case 0:
+            firstLabel.textColor = UIColor(resource: .cgvG700)
+        case 1:
+            secondLabel.textColor = UIColor(resource: .cgvG700)
+        case 2:
+            thirdLabel.textColor = UIColor(resource: .cgvG700)
+        case 3:
+            fourthLabel.textColor = UIColor(resource: .cgvG700)
+        default:
+            break
+        }
+    }
+}

--- a/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ProgressShareCell: BaseCollectionViewCell {
+final class ProgressShareCell: BaseCollectionViewCell {
     
     // MARK: - Property
     

--- a/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
@@ -9,12 +9,16 @@ import UIKit
 
 class ProgressShareCell: BaseCollectionViewCell {
     
+    // MARK: - Property
+    
     private let progressStackView = UIStackView()
     private let firstLabel = UILabel()
     private let secondLabel = UILabel()
     private let thirdLabel = UILabel()
     private let fourthLabel = UILabel()
     private let shareButton = UIButton()
+    
+    // MARK: - UISetting
     
     override func setStyle() {        
         [firstLabel, secondLabel, thirdLabel, fourthLabel].forEach { label in
@@ -55,6 +59,8 @@ class ProgressShareCell: BaseCollectionViewCell {
             $0.centerY.equalToSuperview()
         }
     }
+    
+    // MARK: - Configure
     
     func configure(to index: Int) {
         [firstLabel, secondLabel, thirdLabel, fourthLabel].forEach {

--- a/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
@@ -12,11 +12,15 @@ import Then
 
 class ReserveRateCell: BaseCollectionViewCell {
     
+    // MARK: - Property
+    
     private let underView = UIView()
     private let posterImageView = UIImageView()
     private let titleLabel = UILabel()
     private let rateLabel = UILabel()
     private let reserveButton = UIButton()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         underView.do {
@@ -77,6 +81,8 @@ class ReserveRateCell: BaseCollectionViewCell {
             $0.height.equalTo(24)
         }
     }
+    
+    // MARK: - Configure
     
     func configure(title: String, rate: String, image: UIImage?) {
         titleLabel.setText(title, style: Kopub.head3, color: .cgvG800)

--- a/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class ReserveRateCell: BaseCollectionViewCell {
+final class ReserveRateCell: BaseCollectionViewCell {
     
     // MARK: - Property
     
@@ -85,8 +85,8 @@ class ReserveRateCell: BaseCollectionViewCell {
     // MARK: - Configure
     
     func configure(title: String, rate: String, image: UIImage?) {
-        titleLabel.setText(title, style: Kopub.head3, color: .cgvG800)
-        rateLabel.setText(rate, style: Kopub.body2, color: .cgvG700)
+        titleLabel.updateText(title)
+        rateLabel.updateText(rate)
         posterImageView.image = image
     }
 }

--- a/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
@@ -37,8 +37,9 @@ class ReserveRateCell: BaseCollectionViewCell {
         }
         
         reserveButton.do {
-            $0.setTitle("예매", for: .normal)
+            $0.setTitle("예매", style: Kopub.body3, color: .white)
             $0.backgroundColor = .cgvR200
+            $0.layer.cornerRadius = 4
         }
     }
     
@@ -71,6 +72,7 @@ class ReserveRateCell: BaseCollectionViewCell {
         
         reserveButton.snp.makeConstraints{
             $0.trailing.equalToSuperview().inset(8)
+            $0.centerY.equalTo(posterImageView.snp.centerY)
             $0.width.equalTo(32)
             $0.height.equalTo(24)
         }

--- a/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class TopHeaderViewCell: BaseCollectionViewCell {
+final class TopHeaderViewCell: BaseCollectionViewCell {
     
     // MARK: - Property
     

--- a/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
@@ -12,7 +12,11 @@ import Then
 
 class TopHeaderViewCell: BaseCollectionViewCell {
     
+    // MARK: - Property
+    
     private let topView = TopHeaderView()
+    
+    // MARK: - UISetting
     
     override func setUI() {
         contentView.addSubview(topView)

--- a/CGV/Presentation/Home/View/Cell/TopTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopTabBarCell.swift
@@ -8,11 +8,12 @@
 import UIKit
 
 class TopTabBarCell: BaseCollectionViewCell {
-        
+    
+    // MARK: - Property
+    
     private let gradientView = UIView()
     private let stackView = UIStackView()
     private let underlineView = UIView()
-    
     private let titles = ["홈", "이벤트", "패스트오더", "기프트샵", "@CGV"]
     private var buttons: [UIButton] = []
     
@@ -21,6 +22,8 @@ class TopTabBarCell: BaseCollectionViewCell {
             updateButtonStyles()
         }
     }
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         stackView.do {
@@ -76,20 +79,22 @@ class TopTabBarCell: BaseCollectionViewCell {
         gradientView.setGradient(for: .cgv)
     }
     
+    // MARK: - Configure
+    
     func configure(action: Selector, target: Any) {
         buttons.forEach { button in
             button.addTarget(target, action: action, for: .touchUpInside)
         }
-    }
-    
-    @objc private func buttonTapped(_ sender: UIButton) {
-        guard let index = buttons.firstIndex(of: sender) else { return }
-        selectedIndex = index
     }
 
     private func updateButtonStyles() {
         for (index, button) in buttons.enumerated() {
             button.isSelected = index == selectedIndex
         }
+    }
+    
+    @objc private func buttonTapped(_ sender: UIButton) {
+        guard let index = buttons.firstIndex(of: sender) else { return }
+        selectedIndex = index
     }
 }

--- a/CGV/Presentation/Home/View/Cell/TopTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopTabBarCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class TopTabBarCell: BaseCollectionViewCell {
+final class TopTabBarCell: BaseCollectionViewCell {
     
     // MARK: - Property
     
@@ -93,7 +93,7 @@ class TopTabBarCell: BaseCollectionViewCell {
         }
     }
     
-    @objc private func buttonTapped(_ sender: UIButton) {
+    @objc private func buttonDidTap(_ sender: UIButton) {
         guard let index = buttons.firstIndex(of: sender) else { return }
         selectedIndex = index
     }

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -49,7 +49,7 @@ final class HomeView: BaseView {
             )
             $0.register(
                 MidHeaderView.self,
-                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+                forSupplementaryViewOfKind: "MidHeader",
                 withReuseIdentifier: MidHeaderView.reuseIdentifier
             )
             $0.register(
@@ -84,6 +84,11 @@ final class HomeView: BaseView {
             $0.register(
                 ProgressShareCell.self,
                 forCellWithReuseIdentifier: ProgressShareCell.reuseIdentifier
+            )
+            $0.register(
+                MidGrayView.self,
+                forSupplementaryViewOfKind: "MidGray",
+                withReuseIdentifier: MidGrayView.reuseIdentifier
             )
         }
     }

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class HomeView: UIView {
+final class HomeView: BaseView {
     
     let collectionView: UICollectionView = {
         let layout = UICollectionViewLayout()
@@ -18,29 +18,20 @@ final class HomeView: UIView {
         return collectionView
     }()
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        setupView()
-        setupConstraints()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupView() {
+    override func setUI() {
         addSubview(collectionView)
     }
     
-    private func setupConstraints() {
+    override func setLayout() {
         collectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
     
-    func setupCollectionView() {
+    func setCollectionView() {
         collectionView.do {
+            $0.showsVerticalScrollIndicator = false
+            
             $0.register(
                 TopHeaderViewCell.self,
                 forCellWithReuseIdentifier: TopHeaderViewCell.reuseIdentifier
@@ -79,6 +70,10 @@ final class HomeView: UIView {
             $0.register(
                 ReserveRateCell.self,
                 forCellWithReuseIdentifier: ReserveRateCell.reuseIdentifier
+            )
+            $0.register(
+                MyCGVCell.self,
+                forCellWithReuseIdentifier: MyCGVCell.reuseIdentifier
             )
         }
     }

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -14,16 +14,19 @@ final class HomeView: BaseView {
     
     // MARK: - Property
     
-    let collectionView: UICollectionView = {
-        let layout = UICollectionViewLayout()
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        return collectionView
-    }()
+    let collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()
+    )
     
     // MARK: - UISetting
     
     override func setUI() {
         addSubview(collectionView)
+        
+        collectionView.do {
+            $0.showsVerticalScrollIndicator = false
+        }
     }
     
     override func setLayout() {
@@ -34,10 +37,8 @@ final class HomeView: BaseView {
     
     // MARK: - Register
     
-    func setCollectionView() {
+    func setRegister() {
         collectionView.do {
-            $0.showsVerticalScrollIndicator = false
-            
             $0.register(
                 TopHeaderViewCell.self,
                 forCellWithReuseIdentifier: TopHeaderViewCell.reuseIdentifier
@@ -49,12 +50,12 @@ final class HomeView: BaseView {
             $0.register(
                 MidHeaderView.self,
                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-                withReuseIdentifier: MidHeaderView.identifier
+                withReuseIdentifier: MidHeaderView.reuseIdentifier
             )
             $0.register(
                 MidTabBarView.self,
-                forSupplementaryViewOfKind: "TabBarKind",
-                withReuseIdentifier: MidTabBarView.identifier
+                forSupplementaryViewOfKind: "MidTabBar",
+                withReuseIdentifier: MidTabBarView.reuseIdentifier
             )
             $0.register(
                 MovieChartCell.self,
@@ -67,11 +68,6 @@ final class HomeView: BaseView {
             $0.register(
                 BigImageCell.self,
                 forCellWithReuseIdentifier: BigImageCell.reuseIdentifier
-            )
-            $0.register(
-                MidHeaderView.self,
-                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-                withReuseIdentifier: MidHeaderView.identifier
             )
             $0.register(
                 ReserveRateCell.self,

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -76,6 +76,10 @@ final class HomeView: UIView {
                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
                 withReuseIdentifier: MidHeaderView.identifier
             )
+            $0.register(
+                ReserveRateCell.self,
+                forCellWithReuseIdentifier: ReserveRateCell.reuseIdentifier
+            )
         }
     }
 }

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -12,11 +12,15 @@ import Then
 
 final class HomeView: BaseView {
     
+    // MARK: - Property
+    
     let collectionView: UICollectionView = {
         let layout = UICollectionViewLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         return collectionView
     }()
+    
+    // MARK: - UISetting
     
     override func setUI() {
         addSubview(collectionView)
@@ -27,6 +31,8 @@ final class HomeView: BaseView {
             $0.edges.equalToSuperview()
         }
     }
+    
+    // MARK: - Register
     
     func setCollectionView() {
         collectionView.do {

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -75,6 +75,10 @@ final class HomeView: BaseView {
                 MyCGVCell.self,
                 forCellWithReuseIdentifier: MyCGVCell.reuseIdentifier
             )
+            $0.register(
+                BottomFooterCell.self,
+                forCellWithReuseIdentifier: BottomFooterCell.reuseIdentifier
+            )
         }
     }
 }

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -79,6 +79,10 @@ final class HomeView: BaseView {
                 BottomFooterCell.self,
                 forCellWithReuseIdentifier: BottomFooterCell.reuseIdentifier
             )
+            $0.register(
+                ProgressShareCell.self,
+                forCellWithReuseIdentifier: ProgressShareCell.reuseIdentifier
+            )
         }
     }
 }

--- a/CGV/Presentation/Home/View/MidGrayView.swift
+++ b/CGV/Presentation/Home/View/MidGrayView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MidGrayView: UICollectionReusableView, ReuseIdentifiable {
+final class MidGrayView: UICollectionReusableView, ReuseIdentifiable {
 
     private let grayView = UIView()
     

--- a/CGV/Presentation/Home/View/MidGrayView.swift
+++ b/CGV/Presentation/Home/View/MidGrayView.swift
@@ -1,0 +1,45 @@
+//
+//  MidGrayView.swift
+//  CGV
+//
+//  Created by 김송희 on 11/26/24.
+//
+
+import UIKit
+
+class MidGrayView: UICollectionReusableView, ReuseIdentifiable {
+
+    private let grayView = UIView()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UISetting
+    
+    private func setStyle() {
+        grayView.backgroundColor = UIColor(resource: .cgvG100)
+    }
+    
+    private func setUI() {
+        addSubview(grayView)
+    }
+    
+    private func setLayout() {
+        grayView.snp.makeConstraints{
+            $0.width.equalTo(375)
+            $0.height.equalTo(10)
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/CGV/Presentation/Home/View/MidHeaderView.swift
+++ b/CGV/Presentation/Home/View/MidHeaderView.swift
@@ -15,7 +15,7 @@ final class MidHeaderView: UICollectionReusableView {
     static let identifier = "MidHeaderView"
     private let titleLabel = UILabel()
     private let allViewButton = UIButton()
-    private let allViewTextLabel = UILabel()
+    private let subtitleLabel = UILabel()
     private let chevronImageView = UIImageView()
     
     // MARK: - Initializer
@@ -43,7 +43,7 @@ final class MidHeaderView: UICollectionReusableView {
             $0.backgroundColor = .clear
         }
         
-        allViewTextLabel.do {
+        subtitleLabel.do {
             $0.setText("전체보기", style: Kopub.body3, color: .cgvG700)
         }
         
@@ -55,7 +55,7 @@ final class MidHeaderView: UICollectionReusableView {
     
     private func setUI() {
         addSubviews(titleLabel, allViewButton)
-        allViewButton.addSubviews(allViewTextLabel, chevronImageView)
+        allViewButton.addSubviews(subtitleLabel, chevronImageView)
     }
     
     private func setLayout() {
@@ -67,13 +67,13 @@ final class MidHeaderView: UICollectionReusableView {
         allViewButton.snp.makeConstraints {
             $0.centerY.equalTo(titleLabel)
             $0.trailing.equalToSuperview()
-            $0.width.equalTo(58)
+            $0.width.equalTo(72)
             $0.height.equalTo(18)
         }
         
-        allViewTextLabel.snp.makeConstraints{
+        subtitleLabel.snp.makeConstraints{
             $0.top.equalToSuperview()
-            $0.leading.equalToSuperview()
+            $0.trailing.equalTo(chevronImageView.snp.leading).offset(-5)
         }
         
         chevronImageView.snp.makeConstraints {
@@ -84,8 +84,9 @@ final class MidHeaderView: UICollectionReusableView {
         }
     }
     
-    func configure(title: String) {
+    func configure(title: String, subtitle: String) {
         titleLabel.setText(title, style: Kopub.head7, color: .cgvBlack)
+        subtitleLabel.setText(subtitle, style: Kopub.body3, color: .cgvG700)
     }
 }
 

--- a/CGV/Presentation/Home/View/MidHeaderView.swift
+++ b/CGV/Presentation/Home/View/MidHeaderView.swift
@@ -10,11 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
-final class MidHeaderView: UICollectionReusableView {
+final class MidHeaderView: UICollectionReusableView, ReuseIdentifiable {
     
     // MARK: - Property
     
-    static let identifier = "MidHeaderView"
     private let titleLabel = UILabel()
     private let allViewButton = UIButton()
     private let subtitleLabel = UILabel()
@@ -89,8 +88,8 @@ final class MidHeaderView: UICollectionReusableView {
     // MARK: - Configure
     
     func configure(title: String, subtitle: String) {
-        titleLabel.setText(title, style: Kopub.head7, color: .cgvBlack)
-        subtitleLabel.setText(subtitle, style: Kopub.body3, color: .cgvG700)
+        titleLabel.updateText(title)
+        subtitleLabel.updateText(subtitle)
     }
 }
 

--- a/CGV/Presentation/Home/View/MidHeaderView.swift
+++ b/CGV/Presentation/Home/View/MidHeaderView.swift
@@ -12,6 +12,8 @@ import Then
 
 final class MidHeaderView: UICollectionReusableView {
     
+    // MARK: - Property
+    
     static let identifier = "MidHeaderView"
     private let titleLabel = UILabel()
     private let allViewButton = UIButton()
@@ -32,7 +34,7 @@ final class MidHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Setup Methods
+    // MARK: - UISetting
     
     private func setStyle() {
         titleLabel.do {
@@ -83,6 +85,8 @@ final class MidHeaderView: UICollectionReusableView {
             $0.height.equalTo(18)
         }
     }
+    
+    // MARK: - Configure
     
     func configure(title: String, subtitle: String) {
         titleLabel.setText(title, style: Kopub.head7, color: .cgvBlack)

--- a/CGV/Presentation/Home/View/MidTabBarView.swift
+++ b/CGV/Presentation/Home/View/MidTabBarView.swift
@@ -14,7 +14,7 @@ final class MidTabBarView: UICollectionReusableView, ReuseIdentifiable {
     
     // MARK: - Property
     
-    lazy var collectionView = UICollectionView(
+    let collectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: UICollectionViewFlowLayout().then {
             $0.scrollDirection = .horizontal

--- a/CGV/Presentation/Home/View/MidTabBarView.swift
+++ b/CGV/Presentation/Home/View/MidTabBarView.swift
@@ -12,6 +12,8 @@ import Then
 
 class MidTabBarView: UICollectionReusableView {
     
+    // MARK: - Property
+    
     static let identifier = "TabBarKind"
     
     private var tabs: [String] = []
@@ -31,6 +33,8 @@ class MidTabBarView: UICollectionReusableView {
         }
     )
     
+    // MARK: - Initializer
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -42,6 +46,8 @@ class MidTabBarView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: - UISetting
     
     private func setStyle() {
         collectionView.do {
@@ -66,6 +72,8 @@ class MidTabBarView: UICollectionReusableView {
         }
     }
     
+    // MARK: - Configure
+    
     func configure(tabs: [String], selectedIndex: Int = 0) {
         self.tabs = tabs
         self.selectedIndex = selectedIndex
@@ -73,7 +81,9 @@ class MidTabBarView: UICollectionReusableView {
     }
 }
 
-extension MidTabBarView: UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
+// MARK: - UICollectionViewDataSource
+
+extension MidTabBarView: UICollectionViewDataSource {
     func collectionView(
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
@@ -92,7 +102,11 @@ extension MidTabBarView: UICollectionViewDelegateFlowLayout, UICollectionViewDat
         cell.configure(title: tabs[indexPath.row], isSelected: indexPath.row == selectedIndex)
         return cell
     }
-    
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension MidTabBarView: UICollectionViewDelegateFlowLayout {
     func collectionView(
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
@@ -112,7 +126,7 @@ extension MidTabBarView: UICollectionViewDelegateFlowLayout, UICollectionViewDat
         let width = title.size(withAttributes: attributes).width + 14
         return CGSize(width: ceil(width), height: 26)
     }
-
 }
+
 
 

--- a/CGV/Presentation/Home/View/MidTabBarView.swift
+++ b/CGV/Presentation/Home/View/MidTabBarView.swift
@@ -10,22 +10,11 @@ import UIKit
 import SnapKit
 import Then
 
-class MidTabBarView: UICollectionReusableView {
+final class MidTabBarView: UICollectionReusableView, ReuseIdentifiable {
     
     // MARK: - Property
     
-    static let identifier = "TabBarKind"
-    
-    private var tabs: [String] = []
-    private var selectedIndex: Int = 0 {
-        didSet {
-            collectionView.reloadData()
-        }
-    }
-    
-    var didSelectTab: ((Int) -> Void)?
-    
-    private lazy var collectionView = UICollectionView(
+    lazy var collectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: UICollectionViewFlowLayout().then {
             $0.scrollDirection = .horizontal
@@ -51,12 +40,6 @@ class MidTabBarView: UICollectionReusableView {
     
     private func setStyle() {
         collectionView.do {
-            $0.delegate = self
-            $0.dataSource = self
-            $0.register(
-                MidTabBarCell.self,
-                forCellWithReuseIdentifier: MidTabBarCell.reuseIdentifier
-            )
             $0.showsHorizontalScrollIndicator = false
             $0.backgroundColor = .clear
         }
@@ -72,61 +55,9 @@ class MidTabBarView: UICollectionReusableView {
         }
     }
     
-    // MARK: - Configure
+    // MARK: - Update
     
-    func configure(tabs: [String], selectedIndex: Int = 0) {
-        self.tabs = tabs
-        self.selectedIndex = selectedIndex
+    func updateTabs() {
         collectionView.reloadData()
     }
 }
-
-// MARK: - UICollectionViewDataSource
-
-extension MidTabBarView: UICollectionViewDataSource {
-    func collectionView(
-        _ collectionView: UICollectionView,
-        numberOfItemsInSection section: Int
-    ) -> Int {
-        return tabs.count
-    }
-    
-    func collectionView(
-        _ collectionView: UICollectionView,
-        cellForItemAt indexPath: IndexPath
-    ) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: MidTabBarCell.reuseIdentifier,
-            for: indexPath
-        ) as? MidTabBarCell else { return UICollectionViewCell() }
-        cell.configure(title: tabs[indexPath.row], isSelected: indexPath.row == selectedIndex)
-        return cell
-    }
-}
-
-// MARK: - UICollectionViewDelegateFlowLayout
-
-extension MidTabBarView: UICollectionViewDelegateFlowLayout {
-    func collectionView(
-        _ collectionView: UICollectionView,
-        didSelectItemAt indexPath: IndexPath
-    ) {
-        selectedIndex = indexPath.row
-        didSelectTab?(selectedIndex)
-    }
-    
-    func collectionView(
-        _ collectionView: UICollectionView,
-        layout collectionViewLayout: UICollectionViewLayout,
-        sizeForItemAt indexPath: IndexPath
-    ) -> CGSize {
-        let title = tabs[indexPath.row]
-        let font = UIFont.setupFont(of: Kopub.body3)
-        let attributes: [NSAttributedString.Key: Any] = [.font: font]
-        let width = title.size(withAttributes: attributes).width + 14
-        return CGSize(width: ceil(width), height: 26)
-    }
-}
-
-
-

--- a/CGV/Presentation/Home/View/TopHeaderView.swift
+++ b/CGV/Presentation/Home/View/TopHeaderView.swift
@@ -9,10 +9,14 @@ import UIKit
 
 class TopHeaderView: BaseView {
     
+    // MARK: - Property
+    
     private let ticketButton = UIButton()
     private let cgvLogo = UIImageView()
     private let searchButton = UIButton()
     private let menuButton = UIButton()
+    
+    // MARK: - UISetting
     
     override func setStyle() {
         ticketButton.do {

--- a/CGV/Presentation/Home/View/TopHeaderView.swift
+++ b/CGV/Presentation/Home/View/TopHeaderView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class TopHeaderView: BaseView {
+final class TopHeaderView: BaseView {
     
     // MARK: - Property
     

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -23,7 +23,7 @@ final class HomeViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-            
+        
         homeView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.leading.trailing.bottom.equalToSuperview()
@@ -63,7 +63,7 @@ final class HomeViewController: BaseViewController {
                 ) as! TopHeaderViewCell
                 return cell
                 
-            case .topTapBar:
+            case .topTabBar:
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: TopTabBarCell.reuseIdentifier,
                     for: indexPath
@@ -101,18 +101,18 @@ final class HomeViewController: BaseViewController {
                 ) as! BigImageCell
                 cell.configure(image: item.image)
                 return cell
-            
-//            case .reserveRate:
-//                let cell = collectionView.dequeueReusableCell(
-//                    withReuseIdentifier: ReserveRateCell.reuseIdentifier,
-//                    for: indexPath
-//                ) as! ReserveRateCell
-//                cell.configure(
-//                    title: item.title,
-//                    rate: item.rate ?? "",
-//                    image: item.image
-//                )
-//                return cell
+                
+            case .specialRate, .todayRate:
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ReserveRateCell.reuseIdentifier,
+                    for: indexPath
+                ) as! ReserveRateCell
+                cell.configure(
+                    title: item.title,
+                    rate: item.rate ?? "",
+                    image: item.image
+                )
+                return cell
             }
             
         }
@@ -154,13 +154,16 @@ final class HomeViewController: BaseViewController {
         for section in HomeSectionType.allCases {
             snapshot.appendSections([section])
             
-            if section == .topHeader {
+            switch section {
+            case .topHeader:
                 let topItem = HomeItem(section: .topHeader, title: "")
                 snapshot.appendItems([topItem], toSection: .topHeader)
-            } else if section == .topTapBar {
-                let segmentedItem = HomeItem(section: .topTapBar, title: "")
-                snapshot.appendItems([segmentedItem], toSection: .topTapBar)
-            } else {
+                
+            case .topTabBar:
+                let segmentedItem = HomeItem(section: .topTabBar, title: "")
+                snapshot.appendItems([segmentedItem], toSection: .topTabBar)
+                
+            default:
                 let items = HomeItem.dummyItems.filter { $0.section == section }
                 snapshot.appendItems(items, toSection: section)
             }
@@ -179,7 +182,7 @@ final class HomeViewController: BaseViewController {
             switch sectionType {
             case .topHeader:
                 return self.createTopViewSection()
-            case .topTapBar:
+            case .topTabBar:
                 return self.createTopTabBarSection()
             case .banner:
                 return self.createBannerSection()
@@ -189,9 +192,8 @@ final class HomeViewController: BaseViewController {
                 return self.createSpecialSection()
             case .todayCGV:
                 return self.createTodayCGVSection()
-//            case .reserveRate:
-//                return nil
-//                // return self.createReserveRateSection()
+            case .specialRate, .todayRate:
+                return self.createRateSection()
             }
         }
     }
@@ -396,6 +398,36 @@ final class HomeViewController: BaseViewController {
         )
         
         section.boundarySupplementaryItems = [midHeader, tabBar]
+        
+        return section
+    }
+    
+    private func createRateSection() -> NSCollectionLayoutSection? {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(335),
+            heightDimension: .absolute(58)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(343),
+            heightDimension: .absolute(58 * 3 + 10 * 2)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .fixed(10)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 36,
+            leading: 20,
+            bottom: 14,
+            trailing: 20
+        )
         
         return section
     }

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 final class HomeViewController: BaseViewController {
     
     private let homeView = HomeView()
+    private var currentSpecialPage: Int = 0
+    private var currentTodayCGVPage: Int = 0
     
     private var dataSource: UICollectionViewDiffableDataSource<HomeSectionType, HomeItem>!
     
@@ -114,6 +116,22 @@ final class HomeViewController: BaseViewController {
                 )
                 return cell
                 
+            case .specialProgress:
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ProgressShareCell.reuseIdentifier,
+                    for: indexPath
+                ) as! ProgressShareCell
+                cell.configure(to: self.currentSpecialPage)
+                return cell
+                
+            case .todayProgress:
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ProgressShareCell.reuseIdentifier,
+                    for: indexPath
+                ) as! ProgressShareCell
+                cell.configure(to: self.currentTodayCGVPage)
+                return cell
+                
             case .specialRate, .todayRate:
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ReserveRateCell.reuseIdentifier,
@@ -202,6 +220,21 @@ final class HomeViewController: BaseViewController {
     
     @objc private func topTabBarChanged(_ sender: UISegmentedControl) { }
     
+    private func updateSpecialProgress(for index: Int) {
+        let indexPath = IndexPath(item: 0, section: HomeSectionType.specialProgress.rawValue)
+        if let cell = homeView.collectionView.cellForItem(at: indexPath) as? ProgressShareCell {
+            cell.configure(to: index)
+        }
+    }
+    
+    private func updateTodayCGVProgress(for index: Int) {
+        let indexPath = IndexPath(item: 0, section: HomeSectionType.todayProgress.rawValue)
+        if let cell = homeView.collectionView.cellForItem(at: indexPath) as? ProgressShareCell {
+            cell.configure(to: index)
+        }
+    }
+
+    
     // MARK: - Layouts
     
     private func createLayout() -> UICollectionViewLayout {
@@ -223,6 +256,8 @@ final class HomeViewController: BaseViewController {
                 return self.createMyCGVSection()
             case .todayCGV:
                 return self.createTodayCGVSection()
+            case .specialProgress, .todayProgress:
+                return self.createProgressShareSection()
             case .specialRate, .todayRate:
                 return self.createRateSection()
             case .bottomfooter:
@@ -350,10 +385,16 @@ final class HomeViewController: BaseViewController {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
         
+        section.visibleItemsInvalidationHandler = { [weak self] visibleItems, point, environment in
+            let groupWidth = 343.0
+            let pageIndex = Int((point.x + groupWidth / 2) / groupWidth)
+            self?.updateSpecialProgress(for: pageIndex)
+        }
+        
         section.contentInsets = NSDirectionalEdgeInsets(
             top: 66,
             leading: 20,
-            bottom: 18,
+            bottom: 24,
             trailing: 20
         )
         
@@ -443,6 +484,12 @@ final class HomeViewController: BaseViewController {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
         
+        section.visibleItemsInvalidationHandler = { [weak self] visibleItems, point, environment in
+            let groupWidth = 343.0
+            let pageIndex = Int((point.x + groupWidth / 2) / groupWidth)
+            self?.updateTodayCGVProgress(for: pageIndex)
+        }
+        
         section.contentInsets = NSDirectionalEdgeInsets(
             top: 66,
             leading: 20,
@@ -497,7 +544,7 @@ final class HomeViewController: BaseViewController {
         let section = NSCollectionLayoutSection(group: group)
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 36,
+            top: 24,
             leading: 20,
             bottom: 14,
             trailing: 20
@@ -533,4 +580,33 @@ final class HomeViewController: BaseViewController {
         
         return section
     }
+    
+    private func createProgressShareSection() -> NSCollectionLayoutSection? {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(375),
+            heightDimension: .absolute(40)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(375),
+            heightDimension: .absolute(40)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
+        
+        return section
+    }
 }
+

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -30,7 +30,7 @@ final class HomeViewController: BaseViewController {
         }
         
         homeView.collectionView.collectionViewLayout = createLayout()
-        homeView.setupCollectionView()
+        homeView.setCollectionView()
         configureDataSource()
         applyInitialSnapshots()
     }
@@ -102,6 +102,18 @@ final class HomeViewController: BaseViewController {
                 cell.configure(image: item.image)
                 return cell
                 
+            case .myCGV:
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: MyCGVCell.reuseIdentifier,
+                    for: indexPath
+                ) as! MyCGVCell
+                cell.configure(
+                    title: item.title,
+                    rate: item.rate ?? "",
+                    image: item.image
+                )
+                return cell
+                
             case .specialRate, .todayRate:
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ReserveRateCell.reuseIdentifier,
@@ -117,7 +129,10 @@ final class HomeViewController: BaseViewController {
             
         }
         
-        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+        dataSource.supplementaryViewProvider = {
+            collectionView,
+            kind,
+            indexPath in
             let section = HomeSectionType(rawValue: indexPath.section)
             
             if kind == UICollectionView.elementKindSectionHeader {
@@ -126,7 +141,10 @@ final class HomeViewController: BaseViewController {
                     withReuseIdentifier: MidHeaderView.identifier,
                     for: indexPath
                 ) as! MidHeaderView
-                header.configure(title: section?.headerTitle ?? "")
+                header.configure(
+                    title: section?.headerTitle ?? "",
+                    subtitle: section?.headerSubtitle ?? ""
+                )
                 return header
             } else if kind == "TabBarKind" {
                 let tabBar = collectionView.dequeueReusableSupplementaryView(
@@ -190,6 +208,8 @@ final class HomeViewController: BaseViewController {
                 return self.createMovieChartSection()
             case .special:
                 return self.createSpecialSection()
+            case .myCGV:
+                return self.createMyCGVSection()
             case .todayCGV:
                 return self.createTodayCGVSection()
             case .specialRate, .todayRate:
@@ -346,6 +366,47 @@ final class HomeViewController: BaseViewController {
         )
         
         section.boundarySupplementaryItems = [midHeader, tabBar]
+        
+        return section
+    }
+    
+    private func createMyCGVSection() -> NSCollectionLayoutSection? {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(335),
+            heightDimension: .absolute(50)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(343),
+            heightDimension: .absolute(50 * 3 + 6 * 2)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .fixed(6)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 34,
+            leading: 20,
+            bottom: 26,
+            trailing: 20
+        )
+        
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(32)
+        )
+        let midHeader = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        
+        section.boundarySupplementaryItems = [midHeader]
         
         return section
     }

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -21,22 +21,18 @@ final class HomeViewController: BaseViewController {
     
     override func loadView() {
         let rootView = UIView()
-        rootView.addSubviews(homeView)
+        rootView.addSubview(homeView)
         view = rootView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        homeView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.bottom.equalToSuperview()
-        }
-        
         homeView.collectionView.collectionViewLayout = createLayout()
-        homeView.setCollectionView()
+        homeView.setRegister()
         configureDataSource()
         applyInitialSnapshots()
+        setLayout()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -47,6 +43,13 @@ final class HomeViewController: BaseViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
+    private func setLayout() {
+        homeView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
     }
 }
 
@@ -64,139 +67,182 @@ extension HomeViewController {
             
             switch item.section {
             case .topHeader:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: TopHeaderViewCell.reuseIdentifier,
                     for: indexPath
-                ) as! TopHeaderViewCell
-                return cell
+                ) as? TopHeaderViewCell {
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .topTabBar:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: TopTabBarCell.reuseIdentifier,
                     for: indexPath
-                ) as! TopTabBarCell
-                cell.configure(action: #selector(self.topTabBarChanged(_:)), target: self)
-                return cell
+                ) as? TopTabBarCell {
+                    cell.configure(action: #selector(self.topTabBarChanged(_:)), target: self)
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .banner:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: BannerImageCell.reuseIdentifier,
                     for: indexPath
-                ) as! BannerImageCell
-                cell.configure(image: item.image)
-                return cell
+                ) as? BannerImageCell {
+                    cell.configure(image: item.image)
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .movieChart:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: MovieChartCell.reuseIdentifier,
                     for: indexPath
-                ) as! MovieChartCell
-                cell.configure(
-                    poster: item.image,
-                    title: item.title,
-                    ageLimit: item.ageLimit,
-                    preEgg: item.preEgg ?? "",
-                    dDay: item.dDay ?? ""
-                )
-                return cell
+                ) as? MovieChartCell {
+                    cell.configure(
+                        poster: item.image,
+                        title: item.title,
+                        ageLimit: item.ageLimit,
+                        preEgg: item.preEgg ?? "",
+                        dDay: item.dDay ?? ""
+                    )
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
-            case .special,
-                    .todayCGV:
-                let cell = collectionView.dequeueReusableCell(
+            case .special, .todayCGV:
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: BigImageCell.reuseIdentifier,
                     for: indexPath
-                ) as! BigImageCell
-                cell.configure(image: item.image)
-                return cell
+                ) as? BigImageCell {
+                    cell.configure(image: item.image)
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .myCGV:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: MyCGVCell.reuseIdentifier,
                     for: indexPath
-                ) as! MyCGVCell
-                cell.configure(
-                    title: item.title,
-                    rate: item.rate ?? "",
-                    image: item.image
-                )
-                return cell
+                ) as? MyCGVCell {
+                    cell.configure(
+                        title: item.title,
+                        rate: item.rate ?? "",
+                        image: item.image
+                    )
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .specialProgress:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ProgressShareCell.reuseIdentifier,
                     for: indexPath
-                ) as! ProgressShareCell
-                cell.configure(to: self.currentSpecialPage)
-                return cell
+                ) as? ProgressShareCell {
+                    cell.configure(to: self.currentSpecialPage)
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .todayProgress:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ProgressShareCell.reuseIdentifier,
                     for: indexPath
-                ) as! ProgressShareCell
-                cell.configure(to: self.currentTodayCGVPage)
-                return cell
+                ) as? ProgressShareCell {
+                    cell.configure(to: self.currentTodayCGVPage)
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
                 
             case .specialRate, .todayRate:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ReserveRateCell.reuseIdentifier,
                     for: indexPath
-                ) as! ReserveRateCell
-                cell.configure(
-                    title: item.title,
-                    rate: item.rate ?? "",
-                    image: item.image
-                )
-                return cell
-            
+                ) as? ReserveRateCell {
+                    cell.configure(
+                        title: item.title,
+                        rate: item.rate ?? "",
+                        image: item.image
+                    )
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
+                
             case .bottomfooter:
-                let cell = collectionView.dequeueReusableCell(
+                if let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: BottomFooterCell.reuseIdentifier,
                     for: indexPath
-                ) as! BottomFooterCell
-                cell.configure(
-                    title: item.title,
-                    image: item.image ?? UIImage()
-                )
-                return cell
+                ) as? BottomFooterCell {
+                    cell.configure(
+                        title: item.title,
+                        image: item.image ?? UIImage()
+                    )
+                    return cell
+                } else {
+                    return UICollectionViewCell()
+                }
             }
             
         }
         
         dataSource.supplementaryViewProvider = {
-            collectionView,
-            kind,
-            indexPath in
+            (collectionView: UICollectionView,
+             kind: String,
+             indexPath: IndexPath) in
             let section = HomeSectionType(rawValue: indexPath.section)
             
-            if kind == UICollectionView.elementKindSectionHeader {
-                let header = collectionView.dequeueReusableSupplementaryView(
+            switch kind  {
+            case UICollectionView.elementKindSectionHeader:
+                if let header = collectionView.dequeueReusableSupplementaryView(
                     ofKind: kind,
-                    withReuseIdentifier: MidHeaderView.identifier,
+                    withReuseIdentifier: MidHeaderView.reuseIdentifier,
                     for: indexPath
-                ) as! MidHeaderView
-                header.configure(
-                    title: section?.headerTitle ?? "",
-                    subtitle: section?.headerSubtitle ?? ""
-                )
-                return header
-            } else if kind == "TabBarKind" {
-                let tabBar = collectionView.dequeueReusableSupplementaryView(
-                    ofKind: kind,
-                    withReuseIdentifier: MidTabBarView.identifier,
-                    for: indexPath
-                ) as! MidTabBarView
-                
-                if let tabs = section?.midTabBarTitle {
-                    tabBar.configure(tabs: tabs)
+                ) as? MidHeaderView {
+                    header.configure(
+                        title: section?.headerTitle ?? "",
+                        subtitle: section?.headerSubtitle ?? ""
+                    )
+                    return header
+                } else {
+                    return UICollectionReusableView()
                 }
                 
-                tabBar.didSelectTab = { selectedIndex in
-                    print("Selected Tab Index: \(selectedIndex)")
+            case "MidTabBar":
+                if let tabBar = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: MidTabBarView.reuseIdentifier,
+                    for: indexPath
+                ) as? MidTabBarView {
+                    
+                    let tabBarController = MidTabBarViewController()
+                    self.addChild(tabBarController)
+                    tabBar.addSubview(tabBarController.view)
+                    tabBarController.view.frame = tabBar.bounds
+                    tabBarController.didMove(toParent: self)
+                    
+                    if let tabs = section?.midTabBarTitle {
+                        tabBarController.configure(tabs: tabs)
+                        tabBarController.onTabSelected = { selectedIndex in
+                            print("Tab selected: \(selectedIndex) in section \(indexPath.section)")
+                        }
+                    }
+                    return tabBar
+                } else {
+                    return UICollectionReusableView()
                 }
-                return tabBar
+            default:
+                return nil
             }
-            return UICollectionReusableView()
         }
     }
     
@@ -368,7 +414,7 @@ extension HomeViewController {
         )
         let tabBar = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: tabBarSize,
-            elementKind: "TabBarKind",
+            elementKind: "MidTabBar",
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: 55)
         )
@@ -426,7 +472,7 @@ extension HomeViewController {
         )
         let tabBar = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: tabBarSize,
-            elementKind: "TabBarKind",
+            elementKind: "MidTabBar",
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: 55)
         )
@@ -525,7 +571,7 @@ extension HomeViewController {
         )
         let tabBar = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: tabBarSize,
-            elementKind: "TabBarKind",
+            elementKind: "MidTabBar",
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: 55)
         )

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -418,6 +418,7 @@ extension HomeViewController {
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: 55)
         )
+        tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
         
         section.boundarySupplementaryItems = [midHeader, tabBar]
         
@@ -476,6 +477,7 @@ extension HomeViewController {
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: 55)
         )
+        tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
         
         section.boundarySupplementaryItems = [midHeader, tabBar]
         
@@ -575,6 +577,7 @@ extension HomeViewController {
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: 55)
         )
+        tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
         
         section.boundarySupplementaryItems = [midHeader, tabBar]
         

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class HomeViewController: BaseViewController {
     
+    // MARK: - Property
+    
     private let homeView = HomeView()
     private var currentSpecialPage: Int = 0
     private var currentTodayCGVPage: Int = 0
@@ -46,6 +48,9 @@ final class HomeViewController: BaseViewController {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }
+}
+
+extension HomeViewController {
     
     // MARK: - DataSource
     
@@ -217,6 +222,11 @@ final class HomeViewController: BaseViewController {
         }
         dataSource.apply(snapshot, animatingDifferences: true)
     }
+}
+
+extension HomeViewController {
+    
+    // MARK: - Helper Methods
     
     @objc private func topTabBarChanged(_ sender: UISegmentedControl) { }
     
@@ -233,7 +243,9 @@ final class HomeViewController: BaseViewController {
             cell.configure(to: index)
         }
     }
+}
 
+extension HomeViewController {
     
     // MARK: - Layouts
     
@@ -609,4 +621,3 @@ final class HomeViewController: BaseViewController {
         return section
     }
 }
-

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -125,6 +125,17 @@ final class HomeViewController: BaseViewController {
                     image: item.image
                 )
                 return cell
+            
+            case .bottomfooter:
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: BottomFooterCell.reuseIdentifier,
+                    for: indexPath
+                ) as! BottomFooterCell
+                cell.configure(
+                    title: item.title,
+                    image: item.image ?? UIImage()
+                )
+                return cell
             }
             
         }
@@ -214,6 +225,8 @@ final class HomeViewController: BaseViewController {
                 return self.createTodayCGVSection()
             case .specialRate, .todayRate:
                 return self.createRateSection()
+            case .bottomfooter:
+                return self.createBottomFooter()
             }
         }
     }
@@ -488,6 +501,34 @@ final class HomeViewController: BaseViewController {
             leading: 20,
             bottom: 14,
             trailing: 20
+        )
+        
+        return section
+    }
+    
+    private func createBottomFooter() -> NSCollectionLayoutSection? {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(375),
+            heightDimension: .absolute(166)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(375),
+            heightDimension: .absolute(166)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 33,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
         )
         
         return section

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -21,13 +21,13 @@ final class HomeViewController: BaseViewController {
     
     override func loadView() {
         let rootView = UIView()
-        rootView.addSubview(homeView)
+        rootView.addSubviews(homeView)
         view = rootView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+                
         homeView.collectionView.collectionViewLayout = createLayout()
         homeView.setRegister()
         configureDataSource()
@@ -202,7 +202,7 @@ extension HomeViewController {
             let section = HomeSectionType(rawValue: indexPath.section)
             
             switch kind  {
-            case UICollectionView.elementKindSectionHeader:
+            case "MidHeader":
                 if let header = collectionView.dequeueReusableSupplementaryView(
                     ofKind: kind,
                     withReuseIdentifier: MidHeaderView.reuseIdentifier,
@@ -240,6 +240,18 @@ extension HomeViewController {
                 } else {
                     return UICollectionReusableView()
                 }
+                
+            case "MidGray":
+                if let divider = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: MidGrayView.reuseIdentifier,
+                    for: indexPath
+                ) as? MidGrayView {
+                    return divider
+                } else {
+                    return UICollectionReusableView()
+                }
+                
             default:
                 return nil
             }
@@ -316,8 +328,10 @@ extension HomeViewController {
                 return self.createTodayCGVSection()
             case .specialProgress, .todayProgress:
                 return self.createProgressShareSection()
-            case .specialRate, .todayRate:
-                return self.createRateSection()
+            case .specialRate:
+                return self.createSpecialRateSection()
+            case .todayRate:
+                return self.createTodayRateSection()
             case .bottomfooter:
                 return self.createBottomFooter()
             }
@@ -402,9 +416,9 @@ extension HomeViewController {
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(32)
         )
-        let midHeader = NSCollectionLayoutBoundarySupplementaryItem(
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
+            elementKind: "MidHeader",
             alignment: .top
         )
         
@@ -420,7 +434,19 @@ extension HomeViewController {
         )
         tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
         
-        section.boundarySupplementaryItems = [midHeader, tabBar]
+        let dividerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(10)
+        )
+        let divider = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: dividerSize,
+            elementKind: "MidGray",
+            alignment: .top,
+            absoluteOffset: CGPoint(x: -20, y: 424)
+        )
+        divider.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -40)
+        
+        section.boundarySupplementaryItems = [header, tabBar, divider]
         
         return section
     }
@@ -461,9 +487,9 @@ extension HomeViewController {
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(32)
         )
-        let midHeader = NSCollectionLayoutBoundarySupplementaryItem(
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
+            elementKind: "MidHeader",
             alignment: .top
         )
         
@@ -479,7 +505,7 @@ extension HomeViewController {
         )
         tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
         
-        section.boundarySupplementaryItems = [midHeader, tabBar]
+        section.boundarySupplementaryItems = [header, tabBar]
         
         return section
     }
@@ -514,13 +540,25 @@ extension HomeViewController {
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(32)
         )
-        let midHeader = NSCollectionLayoutBoundarySupplementaryItem(
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
+            elementKind: "MidHeader",
             alignment: .top
         )
         
-        section.boundarySupplementaryItems = [midHeader]
+        let dividerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(10)
+        )
+        let divider = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: dividerSize,
+            elementKind: "MidGray",
+            alignment: .top,
+            absoluteOffset: CGPoint(x: -20, y: 234)
+        )
+        divider.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -40)
+        
+        section.boundarySupplementaryItems = [header, divider]
         
         return section
     }
@@ -561,9 +599,9 @@ extension HomeViewController {
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(32)
         )
-        let midHeader = NSCollectionLayoutBoundarySupplementaryItem(
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
+            elementKind: "MidHeader",
             alignment: .top
         )
         
@@ -579,12 +617,56 @@ extension HomeViewController {
         )
         tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
         
-        section.boundarySupplementaryItems = [midHeader, tabBar]
+        section.boundarySupplementaryItems = [header, tabBar]
         
         return section
     }
     
-    private func createRateSection() -> NSCollectionLayoutSection? {
+    private func createSpecialRateSection() -> NSCollectionLayoutSection? {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(335),
+            heightDimension: .absolute(58)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(343),
+            heightDimension: .absolute(58 * 3 + 10 * 2)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .fixed(10)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 24,
+            leading: 20,
+            bottom: 14,
+            trailing: 20
+        )
+        
+        let dividerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(10)
+        )
+        let divider = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: dividerSize,
+            elementKind: "MidGray",
+            alignment: .top,
+            absoluteOffset: CGPoint(x: -20, y: 253)
+        )
+        divider.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -40)
+        
+        section.boundarySupplementaryItems = [divider]
+        
+        return section
+    }
+    
+    private func createTodayRateSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(335),
             heightDimension: .absolute(58)
@@ -670,3 +752,4 @@ extension HomeViewController {
         return section
     }
 }
+

--- a/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
+++ b/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
@@ -104,7 +104,7 @@ extension MidTabBarViewController: UICollectionViewDelegateFlowLayout {
         let title = tabs[indexPath.row]
         let font = UIFont.setupFont(of: Kopub.body3)
         let attributes: [NSAttributedString.Key: Any] = [.font: font]
-        let width = title.size(withAttributes: attributes).width + 14
+        let width = title.size(withAttributes: attributes).width + 19
         return CGSize(width: ceil(width), height: 26)
     }
 }

--- a/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
+++ b/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
@@ -1,0 +1,110 @@
+//
+//  MidTabBarViewController.swift
+//  CGV
+//
+//  Created by 김송희 on 11/26/24.
+//
+
+import UIKit
+
+class MidTabBarViewController: BaseViewController {
+    
+    // MARK: - Property
+    
+    private let midTabBarView = MidTabBarView()
+    private var tabs: [String] = []
+    private var selectedIndex: Int = 0 {
+        didSet {
+            midTabBarView.collectionView.reloadData()
+        }
+    }
+    var onTabSelected: ((Int) -> Void)?
+    
+    // MARK: - LifeCycle
+    
+    override func loadView() {
+        self.view = midTabBarView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupCollectionView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
+    // MARK: - Set CollectionView
+    
+    private func setupCollectionView() {
+        midTabBarView.collectionView.delegate = self
+        midTabBarView.collectionView.dataSource = self
+        midTabBarView.collectionView.register(
+            MidTabBarCell.self,
+            forCellWithReuseIdentifier: MidTabBarCell.reuseIdentifier
+        )
+    }
+    
+    // MARK: - Configuration
+    
+    func configure(tabs: [String], selectedIndex: Int = 0) {
+        self.tabs = tabs
+        self.selectedIndex = selectedIndex
+        midTabBarView.updateTabs()
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension MidTabBarViewController: UICollectionViewDataSource {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        return tabs.count
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: MidTabBarCell.reuseIdentifier,
+            for: indexPath
+        ) as? MidTabBarCell else { return UICollectionViewCell() }
+        cell.configure(title: tabs[indexPath.row], isSelected: indexPath.row == selectedIndex)
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension MidTabBarViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        selectedIndex = indexPath.row
+        onTabSelected?(selectedIndex)
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        let title = tabs[indexPath.row]
+        let font = UIFont.setupFont(of: Kopub.body3)
+        let attributes: [NSAttributedString.Key: Any] = [.font: font]
+        let width = title.size(withAttributes: attributes).width + 14
+        return CGSize(width: ceil(width), height: 26)
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #10

## 📄 작업 내용
- 예매율 섹션 구현
- myCGV 섹션 구현
- 푸터 구현
- 페이지네이션 구현

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 예매율 | <img src = "https://github.com/user-attachments/assets/884bad28-e0b9-4d4d-a819-f8577d2f3494" width ="250"> |
| myCGV | <img src = "https://github.com/user-attachments/assets/2eb3f05b-fe36-4e4d-a5da-f589b886e98f" width ="250"> |
| 푸터 | <img src = "https://github.com/user-attachments/assets/95b9028b-88b7-463a-926d-97b70f250bbe" width ="250"> |
| 페이지네이션 | <img src = "https://github.com/user-attachments/assets/fbfbe2f5-2d41-40f5-bdea-1e9a209f37e9" width ="250"> |
| 전체 화면 | <img src = "https://github.com/user-attachments/assets/73032d54-03a4-4840-9350-6186f13be41a" width ="250"> |


## 💻 주요 코드 설명
### 페이지네이션

- 특별관 섹션과 오늘의 CGV 섹션에서 페이징으로 화면 전환 시 페이지네이션이 전환됩니다.

<details>
<summary>HomeViewController.swift</summary>

```swift
private func updateSpecialProgress(for index: Int) {
        let indexPath = IndexPath(item: 0, section: HomeSectionType.specialProgress.rawValue)
        if let cell = homeView.collectionView.cellForItem(at: indexPath) as? ProgressShareCell {
            cell.configure(to: index)
        }
    }

section.visibleItemsInvalidationHandler = { [weak self] visibleItems, point, environment in
            let groupWidth = 343.0
            let pageIndex = Int((point.x + groupWidth / 2) / groupWidth)
            self?.updateSpecialProgress(for: pageIndex)
        }
```
</details>


## 👀 기타 더 이야기해볼 점
- 디테일하게 부족한 부분들이 있지만 전반적인 UI는 완료되어 PR 올립니다.
- 추가로 보완하여야 할 부분 관련해서 조언 부탁드립니다. ㅠㅠ
  - [ ] Footer에서 개인정보 처리방침이 다른 버튼들과 높이가 달라서 레이아웃이 안 맞아요
  - [ ] Footer 아래쪽으로 완전히 회색이어야 하는데, 흰색이 생겨요
  - [ ] MidTabBar가 스크롤 될 때 trailing이 superView 맨 끝까지로 설정되어야 해요
  - [ ] 좌측 상단 티켓 아이콘 수정이 필요해요
  - [ ] 섹션 중간에 회색 Divider를 넣어야 해요