### PR TITLE
[feat] 좌석 선택 뷰 기기 대응 반영

### DIFF
--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		A300A4792CEF3EF90063DFF4 /* SeatsTimeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300A4782CEF3EF90063DFF4 /* SeatsTimeModel.swift */; };
 		A300A4802CF021360063DFF4 /* BookingSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300A47F2CF021360063DFF4 /* BookingSheetViewController.swift */; };
 		A300A4822CF021410063DFF4 /* BookingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300A4812CF021410063DFF4 /* BookingSheetView.swift */; };
+		A300A4CA2CF58C6C0063DFF4 /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300A4C92CF58C6C0063DFF4 /* Screen.swift */; };
 		A36348B82CE8E937003B5322 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36348B72CE8E937003B5322 /* AppDelegate.swift */; };
 		A36348BA2CE8E937003B5322 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36348B92CE8E937003B5322 /* SceneDelegate.swift */; };
 		A36348C12CE8E938003B5322 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A36348C02CE8E938003B5322 /* Assets.xcassets */; };
@@ -93,6 +94,7 @@
 		A300A4782CEF3EF90063DFF4 /* SeatsTimeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeatsTimeModel.swift; sourceTree = "<group>"; };
 		A300A47F2CF021360063DFF4 /* BookingSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingSheetViewController.swift; sourceTree = "<group>"; };
 		A300A4812CF021410063DFF4 /* BookingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingSheetView.swift; sourceTree = "<group>"; };
+		A300A4C92CF58C6C0063DFF4 /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		A36348B42CE8E937003B5322 /* CGV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CGV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A36348B72CE8E937003B5322 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A36348B92CE8E937003B5322 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 			isa = PBXGroup;
 			children = (
 				A36349272CEA7D89003B5322 /* ReuseIdentifable.swift */,
+				A300A4C92CF58C6C0063DFF4 /* Screen.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				A36349082CEA4AA0003B5322 /* UIFont+.swift in Sources */,
 				A300A4792CEF3EF90063DFF4 /* SeatsTimeModel.swift in Sources */,
 				003919E62CEDE81C005B7C43 /* TopTabBarCell.swift in Sources */,
+				A300A4CA2CF58C6C0063DFF4 /* Screen.swift in Sources */,
 				0032F4B92CEDC4D500F14451 /* TopHeaderView.swift in Sources */,
 				A36349062CEA4A70003B5322 /* UIStackView+.swift in Sources */,
 				00C7742C2CEB9A5E0020F5BA /* BigImageCell.swift in Sources */,

--- a/CGV/Presentation/Seats/View/BookingSheetView.swift
+++ b/CGV/Presentation/Seats/View/BookingSheetView.swift
@@ -162,14 +162,14 @@ final class BookingSheetView: BaseView {
         }
         
         editCountButton.snp.makeConstraints {
-            $0.centerY.equalTo(guestCountLabel.snp.centerY)
+            $0.centerY.equalTo(guestCountLabel.snp.centerY).offset(Screen.height(2))
             $0.leading.equalTo(guestCountLabel.snp.trailing).offset(Screen.width(8))
             $0.width.equalTo(Screen.width(66))
             $0.height.equalTo(Screen.height(26))
         }
         
         priceStackView.snp.makeConstraints {
-            $0.centerY.equalTo(guestCountLabel.snp.centerY)
+            $0.centerY.equalTo(guestCountLabel.snp.centerY).offset(Screen.height(2))
             $0.trailing.equalToSuperview().inset(Screen.width(20))
         }
         

--- a/CGV/Presentation/Seats/View/BookingSheetView.swift
+++ b/CGV/Presentation/Seats/View/BookingSheetView.swift
@@ -50,7 +50,7 @@ final class BookingSheetView: BaseView {
         }
         
         dateLabel.do {
-            $0.setText("2024.11.9 (토)", style: Kopub.head4, color: .cgvG700, isSingleLine: true)
+            $0.setText("2024.11.05 (월)", style: Kopub.head4, color: .cgvG700, isSingleLine: true)
         }
         
         theaterLabel.do {
@@ -147,36 +147,36 @@ final class BookingSheetView: BaseView {
     
     override func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(40)
+            $0.top.equalToSuperview().inset(Screen.height(40))
             $0.centerX.equalToSuperview()
         }
         
         infoStackView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(Screen.height(16))
             $0.centerX.equalToSuperview()
         }
         
         guestCountLabel.snp.makeConstraints {
-            $0.top.equalTo(infoStackView.snp.bottom).offset(20)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(infoStackView.snp.bottom).offset(Screen.height(20))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         editCountButton.snp.makeConstraints {
             $0.centerY.equalTo(guestCountLabel.snp.centerY)
-            $0.leading.equalTo(guestCountLabel.snp.trailing).offset(8)
-            $0.width.equalTo(66)
-            $0.height.equalTo(26)
+            $0.leading.equalTo(guestCountLabel.snp.trailing).offset(Screen.width(8))
+            $0.width.equalTo(Screen.width(66))
+            $0.height.equalTo(Screen.height(26))
         }
         
         priceStackView.snp.makeConstraints {
             $0.centerY.equalTo(guestCountLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
         }
         
         bookingButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(36)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.bottom.equalToSuperview().inset(Screen.height(36))
+            $0.leading.trailing.equalToSuperview().inset(Screen.width(20))
+            $0.height.equalTo(Screen.height(60))
         }
     }
 }

--- a/CGV/Presentation/Seats/View/Cell/SeatsCollectionViewCell.swift
+++ b/CGV/Presentation/Seats/View/Cell/SeatsCollectionViewCell.swift
@@ -88,7 +88,7 @@ final class SeatsCollectionViewCell: BaseCollectionViewCell {
         }
         
         seatsView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(40)
+            $0.top.equalToSuperview().inset(Screen.height(40))
             $0.leading.trailing.bottom.equalToSuperview()
         }
         
@@ -98,9 +98,9 @@ final class SeatsCollectionViewCell: BaseCollectionViewCell {
         }
         
         seatsStackView.snp.makeConstraints {
-            $0.centerY.equalTo(seatsView.snp.centerY).offset(-4)
+            $0.centerY.equalTo(seatsView.snp.centerY).offset(-Screen.height(4))
             $0.centerX.equalTo(seatsView.snp.centerX)
-            $0.height.equalTo(20)
+            $0.height.equalTo(Screen.height(20))
         }
         
         remainSeatsLabel.snp.makeConstraints {

--- a/CGV/Presentation/Seats/View/GuestCountSheetView.swift
+++ b/CGV/Presentation/Seats/View/GuestCountSheetView.swift
@@ -62,7 +62,7 @@ final class GuestCountSheetView: BaseView {
         }
         
         dateLabel.do {
-            $0.setText("2024.11.9 (토)", style: Kopub.head4, color: .cgvG700, isSingleLine: true)
+            $0.setText("2024.11.05 (월)", style: Kopub.head4, color: .cgvG700, isSingleLine: true)
         }
         
         theaterLabel.do {
@@ -172,85 +172,85 @@ final class GuestCountSheetView: BaseView {
     
     override func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(40)
+            $0.top.equalToSuperview().inset(Screen.height(40))
             $0.centerX.equalToSuperview()
         }
         
         infoStackView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(Screen.height(16))
             $0.centerX.equalToSuperview()
         }
         
         guestCountLabel.snp.makeConstraints {
-            $0.top.equalTo(infoStackView.snp.bottom).offset(15)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(infoStackView.snp.bottom).offset(Screen.height(18))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         maxCountLabel.snp.makeConstraints {
-            $0.centerY.equalTo(guestCountLabel.snp.centerY).offset(2)
-            $0.leading.equalTo(guestCountLabel.snp.trailing).offset(8)
+            $0.centerY.equalTo(guestCountLabel.snp.centerY).offset(Screen.height(2))
+            $0.leading.equalTo(guestCountLabel.snp.trailing).offset(Screen.width(8))
         }
         
         generalLabel.snp.makeConstraints {
-            $0.top.equalTo(guestCountLabel.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(guestCountLabel.snp.bottom).offset(Screen.height(20))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         youthLabel.snp.makeConstraints {
-            $0.top.equalTo(generalLabel.snp.bottom).offset(26)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(generalLabel.snp.bottom).offset(Screen.height(26))
+            $0.leading.equalToSuperview().inset(Screen.height(20))
         }
         
         seniorLabel.snp.makeConstraints {
-            $0.top.equalTo(youthLabel.snp.bottom).offset(26)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(youthLabel.snp.bottom).offset(Screen.height(26))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         discountLabel.snp.makeConstraints {
-            $0.top.equalTo(seniorLabel.snp.bottom).offset(26)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(seniorLabel.snp.bottom).offset(Screen.height(26))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         generalButton.snp.makeConstraints {
             $0.centerY.equalTo(generalLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
             $0.width.equalTo(GuestCountButton.defaultWidth)
             $0.height.equalTo(GuestCountButton.defaultHeight)
         }
         
         youthButton.snp.makeConstraints {
             $0.centerY.equalTo(youthLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
             $0.width.equalTo(GuestCountButton.defaultWidth)
             $0.height.equalTo(GuestCountButton.defaultHeight)
         }
         
         seniorButton.snp.makeConstraints {
             $0.centerY.equalTo(seniorLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
             $0.width.equalTo(GuestCountButton.defaultWidth)
             $0.height.equalTo(GuestCountButton.defaultHeight)
         }
         
         discountButton.snp.makeConstraints {
             $0.centerY.equalTo(discountLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
             $0.width.equalTo(GuestCountButton.defaultWidth)
             $0.height.equalTo(GuestCountButton.defaultHeight)
         }
         
         backButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(36)
-            $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalToSuperview().inset((UIScreen.main.bounds.width / 2) + 10)
-            $0.height.equalTo(60)
+            $0.bottom.equalToSuperview().inset(Screen.height(36))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
+            $0.width.equalTo(Screen.width(162))
+            $0.height.equalTo(Screen.height(60))
         }
         
         selectButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(36)
-            $0.leading.equalToSuperview().inset((UIScreen.main.bounds.width / 2) + 10)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.bottom.equalToSuperview().inset(Screen.height(36))
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
+            $0.width.equalTo(Screen.width(162))
+            $0.height.equalTo(Screen.height(60))
         }
     }
 }

--- a/CGV/Presentation/Seats/View/SeatsView.swift
+++ b/CGV/Presentation/Seats/View/SeatsView.swift
@@ -34,6 +34,9 @@ final class SeatsView: BaseView {
         
         seatsImage.do {
             $0.setImage(.imgSeatsUnselected, for: .normal)
+            $0.imageView?.contentMode = .scaleAspectFill
+            $0.contentHorizontalAlignment = .fill
+            $0.contentVerticalAlignment = .fill
         }
     }
     
@@ -43,15 +46,16 @@ final class SeatsView: BaseView {
     
     override func setLayout() {
         seatsCollectionView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(90)
+            $0.top.equalToSuperview().inset(Screen.height(90))
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(80)
+            $0.height.equalTo(Screen.height(80))
         }
         
         seatsImage.snp.makeConstraints {
             $0.top.equalTo(seatsCollectionView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(UIScreen.main.bounds.width * (641/375))
+            $0.width.equalTo(Screen.width(375))
+            $0.height.equalTo(Screen.height(641))
         }
     }
 }

--- a/CGV/Presentation/Seats/ViewController/SeatsViewController.swift
+++ b/CGV/Presentation/Seats/ViewController/SeatsViewController.swift
@@ -15,10 +15,10 @@ final class SeatsViewController: BaseViewController {
     
     private let timeList = SeatsTimeModel.mockTimeData()
     
-    final let cellWidth: CGFloat = 90
-    final let cellHeight: CGFloat = 63
+    final let cellWidth: CGFloat = Screen.width(90)
+    final let cellHeight: CGFloat = Screen.height(63)
     final let contentInterSpacing: CGFloat = 4
-    final let contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+    final let contentInset = UIEdgeInsets(top: 0, left: Screen.width(20), bottom: 0, right: Screen.width(20))
     
     // MARK: - LifeCycle
     

--- a/CGV/Resource/Components/GuestCountButton.swift
+++ b/CGV/Resource/Components/GuestCountButton.swift
@@ -14,9 +14,9 @@ final class GuestCountButton: UIView {
     
     // MARK: - Property
 
-    static let defaultWidth: CGFloat = 100
+    static let defaultWidth: CGFloat = Screen.width(100)
     
-    static let defaultHeight: CGFloat = 42
+    static let defaultHeight: CGFloat = Screen.height(42)
     
     var currentCount: Int {
         return Int(countLabel.text ?? "0") ?? 0
@@ -130,7 +130,8 @@ private extension GuestCountButton {
         countView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.centerY.equalToSuperview()
-            $0.size.equalTo(34)
+            $0.width.equalTo(Screen.width(34))
+            $0.height.equalTo(Screen.height(34))
         }
         
         countLabel.snp.makeConstraints {
@@ -140,14 +141,16 @@ private extension GuestCountButton {
         
         minusButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(8)
-            $0.size.equalTo(20)
+            $0.leading.equalToSuperview().inset(Screen.width(8))
+            $0.width.equalTo(Screen.width(20))
+            $0.height.equalTo(Screen.height(20))
         }
         
         plusButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(8)
-            $0.size.equalTo(20)
+            $0.trailing.equalToSuperview().inset(Screen.width(8))
+            $0.width.equalTo(Screen.width(20))
+            $0.height.equalTo(Screen.height(20))
         }
     }
 }

--- a/CGV/Resource/Extensions/UIFont+.swift
+++ b/CGV/Resource/Extensions/UIFont+.swift
@@ -36,6 +36,8 @@ extension UIFont {
 }
 
 enum Kopub: FontStyle {
+    private static let scaleRatio: CGFloat = max(Screen.height(1), Screen.width(1))
+    
     case head1, head2, head3, head4, head5, head6, head7, head8
     case body1, body2, body3, body4, body5
     
@@ -49,6 +51,10 @@ enum Kopub: FontStyle {
     }
     
     var size: CGFloat {
+        return defaultSize * Kopub.scaleRatio
+    }
+    
+    var defaultSize: CGFloat {
         switch self {
         case .head1: 10
         case .head2: 12
@@ -88,6 +94,8 @@ enum Kopub: FontStyle {
 }
 
 enum Malgun: FontStyle {
+    private static let scaleRatio: CGFloat = max(Screen.height(1), Screen.width(1))
+    
     case head1, head2, head3
     case body1, body2, body3, body4
     
@@ -101,6 +109,10 @@ enum Malgun: FontStyle {
     }
     
     var size: CGFloat {
+        return defaultSize * Malgun.scaleRatio
+    }
+    
+    var defaultSize: CGFloat {
         switch self {
         case .head1: 12
         case .head2: 16

--- a/CGV/Resource/Util/Screen.swift
+++ b/CGV/Resource/Util/Screen.swift
@@ -1,0 +1,22 @@
+//
+//  Screen.swift
+//  CGV
+//
+//  Created by 예삐 on 11/26/24.
+//
+
+import UIKit
+
+enum Screen {
+    static func width(_ value: CGFloat) -> CGFloat {
+        let screenWidth = UIScreen.main.bounds.width
+        let designWidth: CGFloat = 375.0
+        return screenWidth / designWidth * value
+    }
+    
+    static func height(_ value: CGFloat) -> CGFloat {
+        let screenHeight = UIScreen.main.bounds.height
+        let designHeight: CGFloat = 812.0
+        return screenHeight / designHeight * value
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #27

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기기 대응 util 코드를 추가하고 그에 맞게 폰트 익스텐션을 수정하였습니다.
- 좌석 선택 뷰에 기기 대응 코드를 반영하였습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 인원 선택 | <img src = "https://github.com/user-attachments/assets/741382c7-bfa1-4556-a5d7-0c72aa206c27" width ="250"> | <img src = "https://github.com/user-attachments/assets/7298fe8c-a9c0-4725-a88b-c22a169b533d" width ="250"> |
| 예매 확인 | <img src = "https://github.com/user-attachments/assets/d081d68a-a4fe-46ab-b451-f07985059099" width ="250"> | <img src = "https://github.com/user-attachments/assets/ffebf8d3-bf2b-44c1-88cc-1a6691a7d857" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 기기 대응 반영하기!

- Screen 유틸 코드를 통해 기기 대응을 반영할 수 있습니다. 디자인 사이즈인 iPhone 13 mini를 기준으로 각 기기의 사이즈를 고려한 CGFloat 값을 새롭게 반환합니다.
- width와 height를 적절히 사용합니다. (leading, trailing의 경우 width를, top, bottom의 경우 height를 사용합니다.)
- size로 묶은 부분이 있다면 이를 width와 height로 해체하여 각각 적용하도록 합니다. (edges의 경우도 마찬가지)
- 사이즈에 관한 상수 값을 선언한 부분이 있다면, 해당 상수에도 반드시 적용하도록 합니다.
- 컴포넌트로 파일을 분리해준 경우도 잊지 말고 적용하도록 합니다.

<details>
<summary>Screen.swift</summary>

```swift
enum Screen {
    static func width(_ value: CGFloat) -> CGFloat {
        let screenWidth = UIScreen.main.bounds.width
        let designWidth: CGFloat = 375.0
        return screenWidth / designWidth * value
    }
    
    static func height(_ value: CGFloat) -> CGFloat {
        let screenHeight = UIScreen.main.bounds.height
        let designHeight: CGFloat = 812.0
        return screenHeight / designHeight * value
    }
}
```
</details>

<details>
<summary>사용 예시</summary>

```swift
static let defaultWidth: CGFloat = Screen.width(100)
static let defaultHeight: CGFloat = Screen.height(42)

plusButton.snp.makeConstraints {
    $0.centerY.equalToSuperview()
    $0.trailing.equalToSuperview().inset(Screen.width(8))
    $0.width.equalTo(Screen.width(20))
    $0.height.equalTo(Screen.height(20))
}
```
</details>

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
✳️ 기기 대응 PR의 경우 반드시 iPhone 13 mini와 iPhone 15 pro의 스크린샷을 모두 첨부합니다. 해당 PR 양식은 노션 PR 템플릿 페이지 하단에 있습니다!
✳️ 기기 대응 PR의 경우 자체 디자인 QA를 진행한 후 올려주세요! 피그마 아요 안녕이들의 뷰 분석 섹션에 예시로 좌석 선택 뷰의 스크린샷을 첨부해두었습니다. PR 작성 전, 피그마의 디자인과 겹쳐 비교해보고 다른 부분이 없는지 비교해봅시다. 미세하게 다른 부분이 있다면 임의로 offset값을 살짝 조정해주셔도 좋습니다! (보통 2~3 픽셀 정도로 조정합니다) 
✳️ 디자인 명세를 정확히 반영하는 것 또한 클라이언트 개발자의 책임이라는 것 꼭 기억해주세요!