### PR TITLE
[feat] 홈화면 기기대응 코드 추가, 레이아웃 수정

### DIFF
--- a/CGV.xcodeproj/project.pbxproj
+++ b/CGV.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0032F4BB2CEDDB4800F14451 /* TopHeaderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032F4BA2CEDDB4800F14451 /* TopHeaderViewCell.swift */; };
 		003919E62CEDE81C005B7C43 /* TopTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */; };
 		0060567F2CEC6C9000482BEC /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0060567E2CEC6C9000482BEC /* HomeView.swift */; };
+		0067A0572CF7780C0062FA42 /* SectionBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0067A0562CF7780C0062FA42 /* SectionBackgroundView.swift */; };
 		00805C6C2CEF242D0016C6F7 /* ReserveRateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */; };
 		00805C702CEFAEC90016C6F7 /* MyCGVCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */; };
 		00AE2A862CEE3A530024CE6C /* MidTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */; };
@@ -78,6 +79,7 @@
 		0032F4BA2CEDDB4800F14451 /* TopHeaderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopHeaderViewCell.swift; sourceTree = "<group>"; };
 		003919E52CEDE81C005B7C43 /* TopTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabBarCell.swift; sourceTree = "<group>"; };
 		0060567E2CEC6C9000482BEC /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		0067A0562CF7780C0062FA42 /* SectionBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionBackgroundView.swift; sourceTree = "<group>"; };
 		00805C6B2CEF242D0016C6F7 /* ReserveRateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReserveRateCell.swift; sourceTree = "<group>"; };
 		00805C6F2CEFAEC90016C6F7 /* MyCGVCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCGVCell.swift; sourceTree = "<group>"; };
 		00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidTabBarView.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				00C774272CEB98830020F5BA /* MidHeaderView.swift */,
 				00AE2A852CEE3A530024CE6C /* MidTabBarView.swift */,
 				0030771C2CF4EF25008F7BDF /* MidGrayView.swift */,
+				0067A0562CF7780C0062FA42 /* SectionBackgroundView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 				0030771B2CF4CB5B008F7BDF /* MidTabBarViewController.swift in Sources */,
 				00BF992C2CF0B69D000920A8 /* ProgressShareCell.swift in Sources */,
 				AD9263F62CEC838600F63581 /* RegionType.swift in Sources */,
+				0067A0572CF7780C0062FA42 /* SectionBackgroundView.swift in Sources */,
 				A36349182CEA6E87003B5322 /* UILabel+.swift in Sources */,
 				A36348E02CE8EB85003B5322 /* HomeViewController.swift in Sources */,
 				AD9263F02CEB747900F63581 /* TimeBottomSheetView.swift in Sources */,

--- a/CGV/Presentation/Home/View/Cell/BannerImageCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BannerImageCell.swift
@@ -39,15 +39,15 @@ final class BannerImageCell: BaseCollectionViewCell {
         bannerImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.equalToSuperview()
-            $0.width.equalTo(375)
-            $0.height.equalTo(100)
+            $0.width.equalTo(Screen.width(375))
+            $0.height.equalTo(Screen.height(100))
         }
         
         countLabel.snp.makeConstraints{
             $0.bottom.equalTo(bannerImageView.snp.bottom)
             $0.trailing.equalTo(bannerImageView.snp.trailing)
-            $0.width.equalTo(33)
-            $0.height.equalTo(18)
+            $0.width.equalTo(Screen.width(33))
+            $0.height.equalTo(Screen.height(18))
         }
     }
     

--- a/CGV/Presentation/Home/View/Cell/BigImageCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BigImageCell.swift
@@ -31,9 +31,8 @@ final class BigImageCell: BaseCollectionViewCell {
     
     override func setLayout() {
         bigImageView.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.leading.equalToSuperview()
-            $0.width.equalToSuperview()
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
         }
     }
     

--- a/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
+++ b/CGV/Presentation/Home/View/Cell/BottomFooterCell.swift
@@ -38,7 +38,7 @@ final class BottomFooterCell: BaseCollectionViewCell {
         buttonStackView.do {
             $0.axis = .horizontal
             $0.distribution = .equalSpacing
-            $0.spacing = 7
+            $0.spacing = Screen.width(7)
             $0.alignment = .top
         }
         
@@ -90,53 +90,54 @@ final class BottomFooterCell: BaseCollectionViewCell {
     
     override func setLayout() {
         titleLabel.snp.makeConstraints{
-            $0.top.equalToSuperview().inset(33)
-            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalToSuperview().inset(Screen.height(33))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         iconImageView.snp.makeConstraints{
-            $0.top.equalTo(titleLabel.snp.top).offset(7)
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
-            $0.size.equalTo(18)
+            $0.top.equalTo(titleLabel.snp.top).offset(Screen.height(7))
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(Screen.width(8))
+            $0.height.equalTo(Screen.height(18))
+            $0.width.equalTo(Screen.width(18))
         }
         
         buttonStackView.snp.makeConstraints{
-            $0.top.equalTo(titleLabel.snp.bottom).offset(11)
-            $0.leading.equalToSuperview().inset(20)
-            $0.height.equalTo(16)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(Screen.height(11))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
         }
         
         firstDivider.snp.makeConstraints{
-            $0.width.equalTo(1)
-            $0.height.equalTo(8)
-            $0.top.equalToSuperview().inset(3)
-            $0.bottom.equalToSuperview().inset(5)
+            $0.width.equalTo(Screen.width(1))
+            $0.height.equalTo(Screen.height(8))
+            $0.centerY.equalToSuperview().offset(Screen.height(-1))
         }
         
         secondDivider.snp.makeConstraints{
-            $0.width.equalTo(1)
-            $0.height.equalTo(8)
+            $0.width.equalTo(Screen.width(1))
+            $0.height.equalTo(Screen.height(8))
+            $0.centerY.equalToSuperview().offset(Screen.height(-1))
         }
         
         thirdDivider.snp.makeConstraints{
-            $0.width.equalTo(1)
-            $0.height.equalTo(8)
+            $0.width.equalTo(Screen.width(1))
+            $0.height.equalTo(Screen.height(8))
+            $0.centerY.equalToSuperview().offset(Screen.height(-1))
         }
         
         userRuleButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview().offset(-1)
+            $0.centerY.equalToSuperview().offset(Screen.height(-1))
         }
         
         dataRuleButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview().offset(-2)
+            $0.centerY.equalToSuperview().offset(Screen.height(-2))
         }
         
         locationRuleButton.snp.makeConstraints{
-            $0.centerY.equalToSuperview().offset(-1)
+            $0.centerY.equalToSuperview().offset(Screen.height(-1))
         }
         
         lawRuleButton.snp.makeConstraints{
-            $0.centerY.equalToSuperview().offset(-1)
+            $0.centerY.equalToSuperview().offset(Screen.height(-1))
         }
     }
     

--- a/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
@@ -44,7 +44,7 @@ final class MidTabBarCell: BaseCollectionViewCell {
             $0.height.equalTo(1)
             $0.width.equalTo(tabNameLabel.snp.width).offset(Screen.width(16))
             $0.top.equalTo(tabNameLabel.snp.bottom).offset(Screen.height(7))
-            $0.leading.equalToSuperview()
+            $0.centerX.equalTo(tabNameLabel.snp.centerX)
         }
     }
     

--- a/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MidTabBarCell.swift
@@ -42,8 +42,8 @@ final class MidTabBarCell: BaseCollectionViewCell {
         
         underlineView.snp.makeConstraints {
             $0.height.equalTo(1)
-            $0.width.equalTo(tabNameLabel.snp.width).offset(16)
-            $0.top.equalTo(tabNameLabel.snp.bottom).offset(7)
+            $0.width.equalTo(tabNameLabel.snp.width).offset(Screen.width(16))
+            $0.top.equalTo(tabNameLabel.snp.bottom).offset(Screen.height(7))
             $0.leading.equalToSuperview()
         }
     }

--- a/CGV/Presentation/Home/View/Cell/MovieChartCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MovieChartCell.swift
@@ -38,7 +38,7 @@ final class MovieChartCell: BaseCollectionViewCell {
         firstStackView.do {
             $0.axis = .horizontal
             $0.alignment = .center
-            $0.spacing = 2
+            $0.spacing = Screen.width(2)
             $0.distribution = .equalSpacing
         }
         
@@ -53,7 +53,7 @@ final class MovieChartCell: BaseCollectionViewCell {
         secondStackView.do {
             $0.axis = .horizontal
             $0.alignment = .center
-            $0.spacing = 6
+            $0.spacing = Screen.width(6)
             $0.distribution = .equalSpacing
         }
         
@@ -106,21 +106,22 @@ final class MovieChartCell: BaseCollectionViewCell {
         posterImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.equalToSuperview()
-            $0.width.equalTo(160)
-            $0.height.equalTo(230)
+            $0.width.equalTo(Screen.width(160))
+            $0.height.equalTo(Screen.height(230))
         }
         
         firstStackView.snp.makeConstraints{
-            $0.top.equalTo(posterImageView.snp.bottom).offset(8)
+            $0.top.equalTo(posterImageView.snp.bottom).offset(Screen.height(8))
             $0.centerX.equalTo(posterImageView.snp.centerX)
         }
         
         titleLabel.snp.makeConstraints {
-            $0.width.lessThanOrEqualTo(119)
+            $0.width.lessThanOrEqualTo(Screen.width(119))
         }
         
         ageLimitImageView.snp.makeConstraints{
-            $0.size.equalTo(22)
+            $0.width.equalTo(Screen.width(22))
+            $0.height.equalTo(Screen.height(22))
         }
         
         secondStackView.snp.makeConstraints{
@@ -129,19 +130,20 @@ final class MovieChartCell: BaseCollectionViewCell {
         }
         
         preEggLogoImageView.snp.makeConstraints{
-            $0.size.equalTo(18)
+            $0.width.equalTo(Screen.width(18))
+            $0.height.equalTo(Screen.height(18))
         }
         
         divider.snp.makeConstraints{
-            $0.width.equalTo(1)
-            $0.height.equalTo(6)
+            $0.width.equalTo(Screen.width(1))
+            $0.height.equalTo(Screen.height(6))
         }
         
         reserveButton.snp.makeConstraints{
-            $0.top.equalTo(secondStackView.snp.bottom).offset(10)
+            $0.top.equalTo(secondStackView.snp.bottom).offset(Screen.height(10))
             $0.centerX.equalTo(posterImageView.snp.centerX)
-            $0.width.equalTo(160)
-            $0.height.equalTo(40)
+            $0.width.equalTo(Screen.width(160))
+            $0.height.equalTo(Screen.height(40))
         }
     }
     

--- a/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
+++ b/CGV/Presentation/Home/View/Cell/MyCGVCell.swift
@@ -44,23 +44,22 @@ final class MyCGVCell: BaseCollectionViewCell {
     override func setLayout() {
         underView.snp.makeConstraints{
             $0.edges.equalToSuperview()
-            $0.width.equalTo(335)
-            $0.height.equalTo(50)
         }
         
         iconView.snp.makeConstraints{
-            $0.top.equalToSuperview().inset(11)
-            $0.leading.equalToSuperview().inset(13)
-            $0.size.equalTo(28)
+            $0.top.equalToSuperview().inset(Screen.height(11))
+            $0.leading.equalToSuperview().inset(Screen.width(13))
+            $0.width.equalTo(Screen.width(28))
+            $0.height.equalTo(Screen.height(28))
         }
         
         titleLabel.snp.makeConstraints{
             $0.centerY.equalTo(iconView.snp.centerY)
-            $0.leading.equalTo(iconView.snp.trailing).offset(8)
+            $0.leading.equalTo(iconView.snp.trailing).offset(Screen.width(8))
         }
         
         rateLabel.snp.makeConstraints{
-            $0.trailing.equalToSuperview().inset(11)
+            $0.trailing.equalToSuperview().inset(Screen.width(11))
             $0.centerY.equalTo(iconView.snp.centerY)
         }
     }

--- a/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ProgressShareCell.swift
@@ -32,7 +32,7 @@ final class ProgressShareCell: BaseCollectionViewCell {
         
         progressStackView.do {
             $0.axis = .horizontal
-            $0.spacing = 8
+            $0.spacing = Screen.width(8)
             $0.alignment = .center
         }
         
@@ -54,8 +54,9 @@ final class ProgressShareCell: BaseCollectionViewCell {
         }
         
         shareButton.snp.makeConstraints{
-            $0.size.equalTo(30)
-            $0.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(Screen.height(30))
+            $0.width.equalTo(Screen.width(30))
+            $0.trailing.equalToSuperview().inset(Screen.width(20))
             $0.centerY.equalToSuperview()
         }
     }

--- a/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
+++ b/CGV/Presentation/Home/View/Cell/ReserveRateCell.swift
@@ -54,19 +54,17 @@ final class ReserveRateCell: BaseCollectionViewCell {
     override func setLayout() {
         underView.snp.makeConstraints{
             $0.edges.equalToSuperview()
-            $0.width.equalTo(335)
-            $0.height.equalTo(58)
         }
         
         posterImageView.snp.makeConstraints{
             $0.leading.top.equalToSuperview()
-            $0.width.equalTo(41)
-            $0.height.equalTo(58)
+            $0.width.equalTo(Screen.width(41))
+            $0.height.equalTo(Screen.height(58))
         }
         
         titleLabel.snp.makeConstraints{
-            $0.leading.equalTo(posterImageView.snp.trailing).offset(14)
-            $0.top.equalToSuperview().inset(11)
+            $0.leading.equalTo(posterImageView.snp.trailing).offset(Screen.width(14))
+            $0.top.equalToSuperview().inset(Screen.height(11))
         }
         
         rateLabel.snp.makeConstraints{
@@ -75,10 +73,10 @@ final class ReserveRateCell: BaseCollectionViewCell {
         }
         
         reserveButton.snp.makeConstraints{
-            $0.trailing.equalToSuperview().inset(8)
+            $0.trailing.equalToSuperview().inset(Screen.width(8))
             $0.centerY.equalTo(posterImageView.snp.centerY)
-            $0.width.equalTo(32)
-            $0.height.equalTo(24)
+            $0.width.equalTo(Screen.width(32))
+            $0.height.equalTo(Screen.height(24))
         }
     }
     

--- a/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
@@ -24,9 +24,9 @@ final class TopHeaderViewCell: BaseCollectionViewCell {
     
     override func setLayout() {
         topView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(12)
-            $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalToSuperview().inset(10)
+            $0.top.equalToSuperview().inset(Screen.height(12))
+            $0.leading.equalToSuperview().inset(Screen.width(20))
+            $0.trailing.equalToSuperview().inset(Screen.width(10))
             $0.bottom.equalToSuperview()
         }
     }

--- a/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopHeaderViewCell.swift
@@ -24,9 +24,9 @@ final class TopHeaderViewCell: BaseCollectionViewCell {
     
     override func setLayout() {
         topView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(Screen.height(12))
-            $0.leading.equalToSuperview().inset(Screen.width(20))
-            $0.trailing.equalToSuperview().inset(Screen.width(10))
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
     }

--- a/CGV/Presentation/Home/View/Cell/TopTabBarCell.swift
+++ b/CGV/Presentation/Home/View/Cell/TopTabBarCell.swift
@@ -30,7 +30,7 @@ final class TopTabBarCell: BaseCollectionViewCell {
             $0.axis = .horizontal
             $0.alignment = .center
             $0.distribution = .equalSpacing
-            $0.spacing = 14
+            $0.spacing = Screen.width(14)
         }
         
         underlineView.do {
@@ -60,15 +60,15 @@ final class TopTabBarCell: BaseCollectionViewCell {
         }
         
         stackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(Screen.width(16))
             $0.centerY.equalToSuperview()
         }
         
         underlineView.snp.makeConstraints {
-            $0.height.equalTo(2)
-            $0.width.equalTo(29)
+            $0.height.equalTo(Screen.height(2))
+            $0.width.equalTo(Screen.width(29))
             $0.bottom.equalTo(gradientView.snp.bottom)
-            $0.leading.equalToSuperview().inset(16)
+            $0.leading.equalToSuperview().inset(Screen.width(16))
         }
     }
     

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -30,6 +30,7 @@ final class HomeView: BaseView {
         
         collectionView.do {
             $0.showsVerticalScrollIndicator = false
+            $0.backgroundColor = .cgvG100
         }
     }
     

--- a/CGV/Presentation/Home/View/HomeView.swift
+++ b/CGV/Presentation/Home/View/HomeView.swift
@@ -19,19 +19,33 @@ final class HomeView: BaseView {
         collectionViewLayout: UICollectionViewFlowLayout()
     )
     
+    private let safeAreaView = UIView()
+    
     // MARK: - UISetting
     
-    override func setUI() {
-        addSubview(collectionView)
+    override func setStyle() {
+        safeAreaView.do {
+            $0.backgroundColor = .white
+        }
         
         collectionView.do {
             $0.showsVerticalScrollIndicator = false
         }
     }
     
+    override func setUI() {
+        addSubviews(collectionView, safeAreaView)
+    }
+    
     override func setLayout() {
+        safeAreaView.snp.makeConstraints{
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.top)
+        }
+        
         collectionView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(safeAreaView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     

--- a/CGV/Presentation/Home/View/MidGrayView.swift
+++ b/CGV/Presentation/Home/View/MidGrayView.swift
@@ -37,8 +37,7 @@ final class MidGrayView: UICollectionReusableView, ReuseIdentifiable {
     
     private func setLayout() {
         grayView.snp.makeConstraints{
-            $0.width.equalTo(375)
-            $0.height.equalTo(10)
+            $0.width.equalTo(Screen.width(375))
             $0.edges.equalToSuperview()
         }
     }

--- a/CGV/Presentation/Home/View/MidHeaderView.swift
+++ b/CGV/Presentation/Home/View/MidHeaderView.swift
@@ -61,27 +61,27 @@ final class MidHeaderView: UICollectionReusableView, ReuseIdentifiable {
     
     private func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(22)
+            $0.top.equalToSuperview().inset(Screen.height(22))
             $0.leading.equalToSuperview()
         }
         
         allViewButton.snp.makeConstraints {
             $0.centerY.equalTo(titleLabel)
             $0.trailing.equalToSuperview()
-            $0.width.equalTo(72)
-            $0.height.equalTo(18)
+            $0.width.equalTo(Screen.width(72))
+            $0.height.equalTo(Screen.height(18))
         }
         
         subtitleLabel.snp.makeConstraints{
             $0.top.equalToSuperview()
-            $0.trailing.equalTo(chevronImageView.snp.leading).offset(-5)
+            $0.trailing.equalTo(chevronImageView.snp.leading).offset(Screen.width(-5))
         }
         
         chevronImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(2)
+            $0.top.equalToSuperview().inset(Screen.height(2))
             $0.trailing.equalToSuperview()
-            $0.width.equalTo(11)
-            $0.height.equalTo(18)
+            $0.width.equalTo(Screen.width(11))
+            $0.height.equalTo(Screen.height(18))
         }
     }
     

--- a/CGV/Presentation/Home/View/MidTabBarView.swift
+++ b/CGV/Presentation/Home/View/MidTabBarView.swift
@@ -18,7 +18,7 @@ final class MidTabBarView: UICollectionReusableView, ReuseIdentifiable {
         frame: .zero,
         collectionViewLayout: UICollectionViewFlowLayout().then {
             $0.scrollDirection = .horizontal
-            $0.minimumLineSpacing = 8
+            $0.minimumLineSpacing = Screen.width(8)
         }
     )
     

--- a/CGV/Presentation/Home/View/SectionBackgroundView.swift
+++ b/CGV/Presentation/Home/View/SectionBackgroundView.swift
@@ -1,0 +1,19 @@
+//
+//  SectionBackgroundView.swift
+//  CGV
+//
+//  Created by 김송희 on 11/28/24.
+//
+
+import UIKit
+
+class SectionBackgroundView: UICollectionReusableView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .white
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/CGV/Presentation/Home/View/TopHeaderView.swift
+++ b/CGV/Presentation/Home/View/TopHeaderView.swift
@@ -19,6 +19,8 @@ final class TopHeaderView: BaseView {
     // MARK: - UISetting
     
     override func setStyle() {
+        self.backgroundColor = .white
+        
         ticketButton.do {
             $0.setImage(UIImage(resource: .icHomeTicket), for: .normal)
             $0.backgroundColor = .clear
@@ -44,28 +46,29 @@ final class TopHeaderView: BaseView {
     
     override func setLayout() {
         ticketButton.snp.makeConstraints{
-            $0.top.leading.equalToSuperview()
+            $0.centerY.equalTo(cgvLogo.snp.centerY)
+            $0.leading.equalToSuperview().inset(Screen.width(20))
             $0.width.equalTo(Screen.width(30))
             $0.height.equalTo(Screen.height(30))
         }
         
         cgvLogo.snp.makeConstraints{
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(Screen.height(8))
             $0.centerX.equalToSuperview()
             $0.height.equalTo(Screen.height(33))
             $0.width.equalTo(Screen.width(71))
         }
         
         searchButton.snp.makeConstraints{
-            $0.top.equalToSuperview()
+            $0.centerY.equalTo(cgvLogo.snp.centerY)
             $0.trailing.equalTo(menuButton.snp.leading)
             $0.width.equalTo(Screen.width(30))
             $0.height.equalTo(Screen.height(30))
         }
         
         menuButton.snp.makeConstraints{
-            $0.top.equalToSuperview()
-            $0.trailing.equalToSuperview()
+            $0.centerY.equalTo(cgvLogo.snp.centerY)
+            $0.trailing.equalToSuperview().inset(Screen.width(10))
             $0.width.equalTo(Screen.width(30))
             $0.height.equalTo(Screen.height(30))
         }

--- a/CGV/Presentation/Home/View/TopHeaderView.swift
+++ b/CGV/Presentation/Home/View/TopHeaderView.swift
@@ -45,23 +45,26 @@ final class TopHeaderView: BaseView {
     override func setLayout() {
         ticketButton.snp.makeConstraints{
             $0.top.leading.equalToSuperview()
-            $0.size.equalTo(30)
+            $0.width.equalTo(Screen.width(30))
+            $0.height.equalTo(Screen.height(30))
         }
         
         cgvLogo.snp.makeConstraints{
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(33)
-            $0.width.equalTo(71)
+            $0.height.equalTo(Screen.height(33))
+            $0.width.equalTo(Screen.width(71))
         }
         
         searchButton.snp.makeConstraints{
             $0.trailing.equalTo(menuButton.snp.leading)
-            $0.size.equalTo(30)
+            $0.width.equalTo(Screen.width(30))
+            $0.height.equalTo(Screen.height(30))
         }
         
         menuButton.snp.makeConstraints{
             $0.trailing.equalToSuperview()
-            $0.size.equalTo(30)
+            $0.width.equalTo(Screen.width(30))
+            $0.height.equalTo(Screen.height(30))
         }
     }
 }

--- a/CGV/Presentation/Home/View/TopHeaderView.swift
+++ b/CGV/Presentation/Home/View/TopHeaderView.swift
@@ -50,18 +50,21 @@ final class TopHeaderView: BaseView {
         }
         
         cgvLogo.snp.makeConstraints{
+            $0.top.equalToSuperview()
             $0.centerX.equalToSuperview()
             $0.height.equalTo(Screen.height(33))
             $0.width.equalTo(Screen.width(71))
         }
         
         searchButton.snp.makeConstraints{
+            $0.top.equalToSuperview()
             $0.trailing.equalTo(menuButton.snp.leading)
             $0.width.equalTo(Screen.width(30))
             $0.height.equalTo(Screen.height(30))
         }
         
         menuButton.snp.makeConstraints{
+            $0.top.equalToSuperview()
             $0.trailing.equalToSuperview()
             $0.width.equalTo(Screen.width(30))
             $0.height.equalTo(Screen.height(30))

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -336,7 +336,7 @@ extension HomeViewController {
     private func createTopViewSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(Screen.width(375)),
-            heightDimension: .absolute(Screen.height(53))
+            heightDimension: .absolute(Screen.height(49))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = itemSize
@@ -351,7 +351,7 @@ extension HomeViewController {
     private func createTopTabBarSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(Screen.width(375)),
-            heightDimension: .absolute(Screen.height(44))
+            heightDimension: .absolute(Screen.height(49))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = itemSize

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -20,9 +20,7 @@ final class HomeViewController: BaseViewController {
     // MARK: - LifeCycle
     
     override func loadView() {
-        let rootView = UIView()
-        rootView.addSubviews(homeView)
-        view = rootView
+        view = homeView
     }
     
     override func viewDidLoad() {
@@ -32,7 +30,6 @@ final class HomeViewController: BaseViewController {
         homeView.setRegister()
         configureDataSource()
         applyInitialSnapshots()
-        setLayout()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -45,11 +42,9 @@ final class HomeViewController: BaseViewController {
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
-    private func setLayout() {
-        homeView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.bottom.equalToSuperview()
-        }
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        homeView.collectionView.contentInsetAdjustmentBehavior = .never
     }
 }
 
@@ -442,12 +437,6 @@ extension HomeViewController {
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: Screen.width(55))
         )
-        tabBar.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: Screen.width(20),
-            bottom: 0,
-            trailing: 0
-        )
         
         let dividerSize = NSCollectionLayoutSize(
             widthDimension: .absolute(Screen.width(375)),
@@ -458,12 +447,6 @@ extension HomeViewController {
             elementKind: "MidGray",
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: Screen.height(424))
-        )
-        divider.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: 0,
-            bottom: 0,
-            trailing: 0
         )
         
         section.boundarySupplementaryItems = [header, tabBar, divider]
@@ -533,12 +516,6 @@ extension HomeViewController {
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: Screen.height(55))
         )
-        tabBar.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: Screen.width(20),
-            bottom: 0,
-            trailing: 0
-        )
         
         section.boundarySupplementaryItems = [header, tabBar]
         
@@ -596,12 +573,6 @@ extension HomeViewController {
             elementKind: "MidGray",
             alignment: .top,
             absoluteOffset: CGPoint(x: Screen.width(0), y: Screen.height(234))
-        )
-        divider.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: 0,
-            bottom: 0,
-            trailing: 0
         )
         
         section.boundarySupplementaryItems = [header, divider]
@@ -671,12 +642,6 @@ extension HomeViewController {
             alignment: .top,
             absoluteOffset: CGPoint(x: 0, y: Screen.height(55))
         )
-        tabBar.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: Screen.width(20),
-            bottom: 0,
-            trailing: 0
-        )
         
         section.boundarySupplementaryItems = [header, tabBar]
         
@@ -719,12 +684,6 @@ extension HomeViewController {
             elementKind: "MidGray",
             alignment: .top,
             absoluteOffset: CGPoint(x: Screen.width(0), y: Screen.height(253))
-        )
-        divider.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: 0,
-            bottom: 0,
-            trailing: 0
         )
         
         section.boundarySupplementaryItems = [divider]
@@ -780,13 +739,6 @@ extension HomeViewController {
         
         let section = NSCollectionLayoutSection(group: group)
         
-        section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: 0,
-            bottom: 0,
-            trailing: 0
-        )
-        
         return section
     }
     
@@ -807,13 +759,6 @@ extension HomeViewController {
         )
         
         let section = NSCollectionLayoutSection(group: group)
-        
-        section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: 0,
-            bottom: 0,
-            trailing: 0
-        )
         
         return section
     }

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -340,8 +340,8 @@ extension HomeViewController {
     
     private func createTopViewSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(53)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(53))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = itemSize
@@ -355,8 +355,8 @@ extension HomeViewController {
     
     private func createTopTabBarSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(44)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(44))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = itemSize
@@ -370,16 +370,19 @@ extension HomeViewController {
     
     private func createBannerSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(375),
-            heightDimension: .absolute(100)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(100))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(375),
-            heightDimension: .absolute(100)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(100))
         )
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
@@ -388,14 +391,14 @@ extension HomeViewController {
     
     private func createMovieChartSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(160),
-            heightDimension: .absolute(332)
+            widthDimension: .absolute(Screen.width(160)),
+            heightDimension: .absolute(Screen.height(332))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(168),
-            heightDimension: .absolute(332)
+            widthDimension: .absolute(Screen.width(168)),
+            heightDimension: .absolute(Screen.height(332))
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
@@ -406,45 +409,61 @@ extension HomeViewController {
         section.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 66,
-            leading: 20,
-            bottom: 18,
-            trailing: 20
+            top: Screen.height(66),
+            leading: Screen.width(20),
+            bottom: Screen.height(18),
+            trailing: Screen.width(20)
         )
         
         let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(32)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(32))
         )
         let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: "MidHeader",
             alignment: .top
         )
+        header.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: Screen.width(20)
+        )
         
         let tabBarSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(44)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(44))
         )
         let tabBar = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: tabBarSize,
             elementKind: "MidTabBar",
             alignment: .top,
-            absoluteOffset: CGPoint(x: 0, y: 55)
+            absoluteOffset: CGPoint(x: 0, y: Screen.width(55))
         )
-        tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
+        tabBar.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: 0
+        )
         
         let dividerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(10)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(10))
         )
         let divider = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: dividerSize,
             elementKind: "MidGray",
             alignment: .top,
-            absoluteOffset: CGPoint(x: -20, y: 424)
+            absoluteOffset: CGPoint(x: 0, y: Screen.height(424))
         )
-        divider.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -40)
+        divider.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
         
         section.boundarySupplementaryItems = [header, tabBar, divider]
         
@@ -453,14 +472,14 @@ extension HomeViewController {
     
     private func createSpecialSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(335),
-            heightDimension: .absolute(335)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(335))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(343),
-            heightDimension: .absolute(335)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(335))
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
@@ -469,41 +488,56 @@ extension HomeViewController {
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
+        section.interGroupSpacing = Screen.width(8)
         
-        section.visibleItemsInvalidationHandler = { [weak self] visibleItems, point, environment in
-            let groupWidth = 343.0
+        section.visibleItemsInvalidationHandler = {
+            [weak self] visibleItems,
+            point,
+            environment in
+            let groupWidth = Screen.width(335)
             let pageIndex = Int((point.x + groupWidth / 2) / groupWidth)
             self?.updateSpecialProgress(for: pageIndex)
         }
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 66,
-            leading: 20,
-            bottom: 24,
-            trailing: 20
+            top: Screen.height(66),
+            leading: Screen.width(20),
+            bottom: Screen.height(24),
+            trailing: Screen.width(20)
         )
         
         let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(32)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(32))
         )
         let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: "MidHeader",
             alignment: .top
         )
+        header.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: Screen.width(20)
+        )
         
         let tabBarSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(44)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(44))
         )
         let tabBar = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: tabBarSize,
             elementKind: "MidTabBar",
             alignment: .top,
-            absoluteOffset: CGPoint(x: 0, y: 55)
+            absoluteOffset: CGPoint(x: 0, y: Screen.height(55))
         )
-        tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
+        tabBar.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: 0
+        )
         
         section.boundarySupplementaryItems = [header, tabBar]
         
@@ -512,51 +546,62 @@ extension HomeViewController {
     
     private func createMyCGVSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(335),
-            heightDimension: .absolute(50)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(50))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(343),
-            heightDimension: .absolute(50 * 3 + 6 * 2)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(50 * 3 + 6 * 2))
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
             repeatingSubitem: item,
             count: 3
         )
-        group.interItemSpacing = .fixed(6)
+        group.interItemSpacing = .fixed(Screen.height(6))
         
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 34,
-            leading: 20,
-            bottom: 26,
-            trailing: 20
+            top: Screen.height(34),
+            leading: Screen.width(20),
+            bottom: Screen.height(26),
+            trailing: Screen.width(20)
         )
         
         let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(32)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(32))
         )
         let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: "MidHeader",
             alignment: .top
         )
+        header.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: Screen.width(20)
+        )
         
         let dividerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(10)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(10))
         )
         let divider = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: dividerSize,
             elementKind: "MidGray",
             alignment: .top,
-            absoluteOffset: CGPoint(x: -20, y: 234)
+            absoluteOffset: CGPoint(x: Screen.width(0), y: Screen.height(234))
         )
-        divider.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -40)
+        divider.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
         
         section.boundarySupplementaryItems = [header, divider]
         
@@ -565,14 +610,14 @@ extension HomeViewController {
     
     private func createTodayCGVSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(335),
-            heightDimension: .absolute(335)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(335))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(343),
-            heightDimension: .absolute(335)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(335))
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
@@ -581,41 +626,56 @@ extension HomeViewController {
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
+        section.interGroupSpacing = Screen.width(8)
         
-        section.visibleItemsInvalidationHandler = { [weak self] visibleItems, point, environment in
-            let groupWidth = 343.0
+        section.visibleItemsInvalidationHandler = {
+            [weak self] visibleItems,
+            point,
+            environment in
+            let groupWidth = Screen.width(335)
             let pageIndex = Int((point.x + groupWidth / 2) / groupWidth)
             self?.updateTodayCGVProgress(for: pageIndex)
         }
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 66,
-            leading: 20,
-            bottom: 18,
-            trailing: 20
+            top: Screen.height(66),
+            leading: Screen.width(20),
+            bottom: Screen.height(24),
+            trailing: Screen.width(20)
         )
         
         let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(32)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(32))
         )
         let header = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: "MidHeader",
             alignment: .top
         )
+        header.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: 20
+        )
         
         let tabBarSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(44)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(44))
         )
         let tabBar = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: tabBarSize,
             elementKind: "MidTabBar",
             alignment: .top,
-            absoluteOffset: CGPoint(x: 0, y: 55)
+            absoluteOffset: CGPoint(x: 0, y: Screen.height(55))
         )
-        tabBar.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -20)
+        tabBar.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Screen.width(20),
+            bottom: 0,
+            trailing: 0
+        )
         
         section.boundarySupplementaryItems = [header, tabBar]
         
@@ -624,42 +684,47 @@ extension HomeViewController {
     
     private func createSpecialRateSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(335),
-            heightDimension: .absolute(58)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(58))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(343),
-            heightDimension: .absolute(58 * 3 + 10 * 2)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(58 * 3 + 10 * 2))
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
             repeatingSubitem: item,
             count: 3
         )
-        group.interItemSpacing = .fixed(10)
+        group.interItemSpacing = .fixed(Screen.height(10))
         
         let section = NSCollectionLayoutSection(group: group)
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 24,
-            leading: 20,
-            bottom: 14,
-            trailing: 20
+            top: Screen.height(24),
+            leading: Screen.width(20),
+            bottom: Screen.height(24),
+            trailing: Screen.width(20)
         )
         
         let dividerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(10)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(10))
         )
         let divider = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: dividerSize,
             elementKind: "MidGray",
             alignment: .top,
-            absoluteOffset: CGPoint(x: -20, y: 253)
+            absoluteOffset: CGPoint(x: Screen.width(0), y: Screen.height(253))
         )
-        divider.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -40)
+        divider.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
         
         section.boundarySupplementaryItems = [divider]
         
@@ -668,29 +733,29 @@ extension HomeViewController {
     
     private func createTodayRateSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(335),
-            heightDimension: .absolute(58)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(58))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(343),
-            heightDimension: .absolute(58 * 3 + 10 * 2)
+            widthDimension: .absolute(Screen.width(335)),
+            heightDimension: .absolute(Screen.height(58 * 3 + 10 * 2))
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
             repeatingSubitem: item,
             count: 3
         )
-        group.interItemSpacing = .fixed(10)
+        group.interItemSpacing = .fixed(Screen.height(10))
         
         let section = NSCollectionLayoutSection(group: group)
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 24,
-            leading: 20,
-            bottom: 14,
-            trailing: 20
+            top: Screen.height(24),
+            leading: Screen.width(20),
+            bottom: Screen.height(24),
+            trailing: Screen.width(20)
         )
         
         return section
@@ -698,14 +763,14 @@ extension HomeViewController {
     
     private func createBottomFooter() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(375),
-            heightDimension: .absolute(166)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(166))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(375),
-            heightDimension: .absolute(166)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(166))
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
@@ -715,7 +780,7 @@ extension HomeViewController {
         let section = NSCollectionLayoutSection(group: group)
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 33,
+            top: Screen.height(33),
             leading: 0,
             bottom: 0,
             trailing: 0
@@ -726,14 +791,14 @@ extension HomeViewController {
     
     private func createProgressShareSection() -> NSCollectionLayoutSection? {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(375),
-            heightDimension: .absolute(40)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(30))
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(375),
-            heightDimension: .absolute(40)
+            widthDimension: .absolute(Screen.width(375)),
+            heightDimension: .absolute(Screen.height(30))
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -754,7 +754,7 @@ extension HomeViewController {
         section.contentInsets = NSDirectionalEdgeInsets(
             top: Screen.height(24),
             leading: Screen.width(20),
-            bottom: Screen.height(24),
+            bottom: Screen.height(51),
             trailing: Screen.width(20)
         )
         
@@ -780,7 +780,7 @@ extension HomeViewController {
         let section = NSCollectionLayoutSection(group: group)
         
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: Screen.height(33),
+            top: 0,
             leading: 0,
             bottom: 0,
             trailing: 0

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -25,7 +25,7 @@ final class HomeViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-                
+        
         homeView.collectionView.collectionViewLayout = createLayout()
         homeView.setRegister()
         configureDataSource()
@@ -303,34 +303,52 @@ extension HomeViewController {
     // MARK: - Layouts
     
     private func createLayout() -> UICollectionViewLayout {
-        UICollectionViewCompositionalLayout { sectionIndex, _ in
+        let layout = UICollectionViewCompositionalLayout { sectionIndex, _ in
             guard let sectionType = HomeSectionType(rawValue: sectionIndex) else { return nil }
+            
+            var section: NSCollectionLayoutSection?
             
             switch sectionType {
             case .topHeader:
-                return self.createTopViewSection()
+                section = self.createTopViewSection()
             case .topTabBar:
-                return self.createTopTabBarSection()
+                section = self.createTopTabBarSection()
             case .banner:
-                return self.createBannerSection()
+                section = self.createBannerSection()
             case .movieChart:
-                return self.createMovieChartSection()
+                section = self.createMovieChartSection()
             case .special:
-                return self.createSpecialSection()
+                section = self.createSpecialSection()
             case .myCGV:
-                return self.createMyCGVSection()
+                section = self.createMyCGVSection()
             case .todayCGV:
-                return self.createTodayCGVSection()
+                section = self.createTodayCGVSection()
             case .specialProgress, .todayProgress:
-                return self.createProgressShareSection()
+                section = self.createProgressShareSection()
             case .specialRate:
-                return self.createSpecialRateSection()
+                section = self.createSpecialRateSection()
             case .todayRate:
-                return self.createTodayRateSection()
+                section = self.createTodayRateSection()
             case .bottomfooter:
-                return self.createBottomFooter()
+                section = self.createBottomFooter()
             }
+            
+            let backgroundDecoration = NSCollectionLayoutDecorationItem.background(
+                elementKind: "SectionBackground"
+            )
+            backgroundDecoration.contentInsets = NSDirectionalEdgeInsets(
+                top: 0, leading: 0, bottom: 0, trailing: 0
+            )
+            section?.decorationItems = [backgroundDecoration]
+            
+            return section
         }
+        
+        layout.register(
+            SectionBackgroundView.self,
+            forDecorationViewOfKind: "SectionBackground"
+        )
+        return layout
     }
     
     private func createTopViewSection() -> NSCollectionLayoutSection {

--- a/CGV/Presentation/Home/ViewController/HomeViewController.swift
+++ b/CGV/Presentation/Home/ViewController/HomeViewController.swift
@@ -397,7 +397,7 @@ extension HomeViewController {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(Screen.width(168)),
+            widthDimension: .absolute(Screen.width(160)),
             heightDimension: .absolute(Screen.height(332))
         )
         let group = NSCollectionLayoutGroup.horizontal(
@@ -407,6 +407,7 @@ extension HomeViewController {
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
+        section.interGroupSpacing = Screen.width(8)
         
         section.contentInsets = NSDirectionalEdgeInsets(
             top: Screen.height(66),

--- a/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
+++ b/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
@@ -107,4 +107,12 @@ extension MidTabBarViewController: UICollectionViewDelegateFlowLayout {
         let width = Screen.width(title.size(withAttributes: attributes).width + 19)
         return CGSize(width: ceil(width), height: Screen.height(26))
     }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+    }
 }

--- a/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
+++ b/CGV/Presentation/Home/ViewController/MidTabBarViewController.swift
@@ -104,7 +104,7 @@ extension MidTabBarViewController: UICollectionViewDelegateFlowLayout {
         let title = tabs[indexPath.row]
         let font = UIFont.setupFont(of: Kopub.body3)
         let attributes: [NSAttributedString.Key: Any] = [.font: font]
-        let width = title.size(withAttributes: attributes).width + 19
-        return CGSize(width: ceil(width), height: 26)
+        let width = Screen.width(title.size(withAttributes: attributes).width + 19)
+        return CGSize(width: ceil(width), height: Screen.height(26))
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #31

## 📄 작업 내용
- 홈화면 기기대응 코드 추가
- 홈화면 레이아웃 수정

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 헤더, 배너, 무비 차트 | <img src = "https://github.com/user-attachments/assets/49488748-06f2-4828-bac9-86dd56e686c7" width ="250"> | <img src = "https://github.com/user-attachments/assets/82878c15-6026-46da-a42c-e879896237be" width ="250"> |
| 특별관 | <img src = "https://github.com/user-attachments/assets/a44a0ffd-ca5e-4da0-8dc8-407e7d66f4e8" width ="250"> | <img src = "https://github.com/user-attachments/assets/398dbda6-2e7b-4469-af5c-1d8e086f6383" width ="250"> |
| 나의 CGV | <img src = "https://github.com/user-attachments/assets/b07ba811-b76f-42ee-8ddd-e37e39149d39" width ="250"> | <img src = "https://github.com/user-attachments/assets/595b7411-d09e-4ba9-a4c3-9983775eb37f" width ="250"> |
| 오늘의 CGV | <img src = "https://github.com/user-attachments/assets/2d41942d-3927-46b3-8d3b-dbd846bfd8a7" width ="250"> | <img src = "https://github.com/user-attachments/assets/f9925a6f-621f-4005-b850-585075bdab67" width ="250"> |
| 푸터 | <img src = "https://github.com/user-attachments/assets/17ec43fc-f325-4ecb-8602-f6db8dd5cadb" width ="250"> | <img src = "https://github.com/user-attachments/assets/615dc0eb-ead2-4a09-ac99-7a162be03c77" width ="250"> |
